### PR TITLE
Quote path in output

### DIFF
--- a/wily/commands/build.py
+++ b/wily/commands/build.py
@@ -38,7 +38,7 @@ def build(config, archiver, operators):
         return
 
     logger.info(
-        f"Found {len(revisions)} revisions from '{archiver.name}' archiver in {config.path}."
+        f"Found {len(revisions)} revisions from '{archiver.name}' archiver in '{config.path}'."
     )
 
     if revisions is None or len(revisions) == 0:


### PR DESCRIPTION
When the the default path of "." is reported, this message is ambiguous:

```
Found 20 revisions from 'git' archiver in ..
```

At first glance, this looks like the parent directory, "`..`", rather than the current directory, "`.`", followed by a stop.