### PR TITLE
Extend the graph command to support multiple axis and recursive path graphing

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,10 @@
 ## 1.6.0 (beta)
 
 * Support for directories in graph command, will recursively scan all .py files and graph them
+* Support for configuring the x-axis on the graph command (defaults to history) to a custom metric
+* Support for configuring the z-axis (size of bubble on scatter) in graph command by specifying a second metric
+* Set metrics to cap at 2 possible options in graph command
+* Running the test suite no longer opens 12 browser windows :-)
 
 ## 1.5.0 (27th November 2018)
 

--- a/test/integration/test_graph.py
+++ b/test/integration/test_graph.py
@@ -1,84 +1,139 @@
+from mock import patch
+
 from click.testing import CliRunner
 
 import wily.__main__ as main
 
 
+PATCHED_ENV = {"BROWSER": "echo %s", "LC_ALL": "C.UTF-8", "LANG": "C.UTF-8"}
+
+
 def test_graph_no_cache(tmpdir):
     runner = CliRunner()
-    result = runner.invoke(
-        main.cli, ["--path", tmpdir, "graph", "src/test.py", "raw.loc"]
-    )
+
+    with patch.dict('os.environ', values=PATCHED_ENV, clear=True):
+        result = runner.invoke(
+            main.cli, ["--path", tmpdir, "graph", "src/test.py", "raw.loc"]
+        )
     assert result.exit_code == 1, result.stdout
 
 
 def test_graph(builddir):
     """ Test the graph feature """
     runner = CliRunner()
-    result = runner.invoke(
-        main.cli, ["--path", builddir, "graph", "src/test.py", "raw.loc"]
-    )
+    with patch.dict('os.environ', values=PATCHED_ENV, clear=True):
+        result = runner.invoke(
+            main.cli, ["--path", builddir, "graph", "src/test.py", "raw.loc"]
+        )
+    assert result.exit_code == 0, result.stdout
+
+
+def test_graph_all(builddir):
+    """ Test the graph feature """
+    runner = CliRunner()
+    with patch.dict('os.environ', values=PATCHED_ENV, clear=True):
+        result = runner.invoke(
+            main.cli, ["--path", builddir, "graph", "src/test.py", "raw.loc", "--all"]
+        )
+    assert result.exit_code == 0, result.stdout
+
+
+def test_graph_changes(builddir):
+    """ Test the graph feature """
+    runner = CliRunner()
+    with patch.dict('os.environ', values=PATCHED_ENV, clear=True):
+        result = runner.invoke(
+            main.cli, ["--path", builddir, "graph", "src/test.py", "raw.loc", "--changes"]
+        )
+    assert result.exit_code == 0, result.stdout
+
+
+def test_graph_custom_x(builddir):
+    """ Test the graph feature """
+    runner = CliRunner()
+    with patch.dict('os.environ', values=PATCHED_ENV, clear=True):
+        result = runner.invoke(
+            main.cli, ["--path", builddir, "graph", "src/test.py", "raw.loc", "-x", "raw.sloc"]
+        )
     assert result.exit_code == 0, result.stdout
 
 
 def test_graph_path(builddir):
     """ Test the graph feature """
     runner = CliRunner()
-    result = runner.invoke(main.cli, ["--path", builddir, "graph", "src/", "raw.loc"])
+    with patch.dict('os.environ', values=PATCHED_ENV, clear=True):
+        result = runner.invoke(main.cli, ["--path", builddir, "graph", "src/", "raw.loc"])
     assert result.exit_code == 0, result.stdout
 
 
 def test_graph_multiple(builddir):
     """ Test the graph feature with multiple metrics """
     runner = CliRunner()
-    result = runner.invoke(
-        main.cli,
-        ["--path", builddir, "graph", "src/test.py", "raw.loc", "raw.comments"],
-    )
+    with patch.dict('os.environ', values=PATCHED_ENV, clear=True):
+        result = runner.invoke(
+            main.cli,
+            ["--path", builddir, "graph", "src/test.py", "raw.loc", "raw.comments"],
+        )
+    assert result.exit_code == 0, result.stdout
+
+
+def test_graph_multiple_custom_x(builddir):
+    """ Test the graph feature with multiple metrics """
+    runner = CliRunner()
+    with patch.dict('os.environ', values=PATCHED_ENV, clear=True):
+        result = runner.invoke(
+            main.cli,
+            ["--path", builddir, "graph", "src/test.py", "raw.loc", "raw.comments", "-x", "raw.sloc"],
+        )
     assert result.exit_code == 0, result.stdout
 
 
 def test_graph_multiple_path(builddir):
     """ Test the graph feature with multiple metrics """
     runner = CliRunner()
-    result = runner.invoke(
-        main.cli, ["--path", builddir, "graph", "src/", "raw.loc", "raw.comments"]
-    )
+    with patch.dict('os.environ', values=PATCHED_ENV, clear=True):
+        result = runner.invoke(
+            main.cli, ["--path", builddir, "graph", "src/", "raw.loc", "raw.comments"]
+        )
     assert result.exit_code == 0, result.stdout
 
 
 def test_graph_output(builddir):
     """ Test the graph feature with target output file """
     runner = CliRunner()
-    result = runner.invoke(
-        main.cli,
-        [
-            "--debug",
-            "--path",
-            builddir,
-            "graph",
-            "src/test.py",
-            "raw.loc",
-            "-o",
-            "test.html",
-        ],
-    )
+    with patch.dict('os.environ', values=PATCHED_ENV, clear=True):
+        result = runner.invoke(
+            main.cli,
+            [
+                "--debug",
+                "--path",
+                builddir,
+                "graph",
+                "src/test.py",
+                "raw.loc",
+                "-o",
+                "test.html",
+            ],
+        )
+
     assert result.exit_code == 0, result.stdout
 
 
 def test_graph_output_granular(builddir):
     """ Test the graph feature with target output file """
     runner = CliRunner()
-    result = runner.invoke(
-        main.cli,
-        [
-            "--debug",
-            "--path",
-            builddir,
-            "graph",
-            "src/test.py:function1",
-            "cyclomatic.complexity",
-            "-o",
-            "test_granular.html",
-        ],
-    )
+    with patch.dict('os.environ', values=PATCHED_ENV, clear=True):
+        result = runner.invoke(
+            main.cli,
+            [
+                "--debug",
+                "--path",
+                builddir,
+                "graph",
+                "src/test.py:function1",
+                "cyclomatic.complexity",
+                "-o",
+                "test_granular.html",
+            ],
+        )
     assert result.exit_code == 0, result.stdout

--- a/test/integration/test_graph.py
+++ b/test/integration/test_graph.py
@@ -11,7 +11,7 @@ PATCHED_ENV = {"BROWSER": "echo %s", "LC_ALL": "C.UTF-8", "LANG": "C.UTF-8"}
 def test_graph_no_cache(tmpdir):
     runner = CliRunner()
 
-    with patch.dict('os.environ', values=PATCHED_ENV, clear=True):
+    with patch.dict("os.environ", values=PATCHED_ENV, clear=True):
         result = runner.invoke(
             main.cli, ["--path", tmpdir, "graph", "src/test.py", "raw.loc"]
         )
@@ -21,7 +21,7 @@ def test_graph_no_cache(tmpdir):
 def test_graph(builddir):
     """ Test the graph feature """
     runner = CliRunner()
-    with patch.dict('os.environ', values=PATCHED_ENV, clear=True):
+    with patch.dict("os.environ", values=PATCHED_ENV, clear=True):
         result = runner.invoke(
             main.cli, ["--path", builddir, "graph", "src/test.py", "raw.loc"]
         )
@@ -31,7 +31,7 @@ def test_graph(builddir):
 def test_graph_all(builddir):
     """ Test the graph feature """
     runner = CliRunner()
-    with patch.dict('os.environ', values=PATCHED_ENV, clear=True):
+    with patch.dict("os.environ", values=PATCHED_ENV, clear=True):
         result = runner.invoke(
             main.cli, ["--path", builddir, "graph", "src/test.py", "raw.loc", "--all"]
         )
@@ -41,9 +41,10 @@ def test_graph_all(builddir):
 def test_graph_changes(builddir):
     """ Test the graph feature """
     runner = CliRunner()
-    with patch.dict('os.environ', values=PATCHED_ENV, clear=True):
+    with patch.dict("os.environ", values=PATCHED_ENV, clear=True):
         result = runner.invoke(
-            main.cli, ["--path", builddir, "graph", "src/test.py", "raw.loc", "--changes"]
+            main.cli,
+            ["--path", builddir, "graph", "src/test.py", "raw.loc", "--changes"],
         )
     assert result.exit_code == 0, result.stdout
 
@@ -51,9 +52,10 @@ def test_graph_changes(builddir):
 def test_graph_custom_x(builddir):
     """ Test the graph feature """
     runner = CliRunner()
-    with patch.dict('os.environ', values=PATCHED_ENV, clear=True):
+    with patch.dict("os.environ", values=PATCHED_ENV, clear=True):
         result = runner.invoke(
-            main.cli, ["--path", builddir, "graph", "src/test.py", "raw.loc", "-x", "raw.sloc"]
+            main.cli,
+            ["--path", builddir, "graph", "src/test.py", "raw.loc", "-x", "raw.sloc"],
         )
     assert result.exit_code == 0, result.stdout
 
@@ -61,15 +63,17 @@ def test_graph_custom_x(builddir):
 def test_graph_path(builddir):
     """ Test the graph feature """
     runner = CliRunner()
-    with patch.dict('os.environ', values=PATCHED_ENV, clear=True):
-        result = runner.invoke(main.cli, ["--path", builddir, "graph", "src/", "raw.loc"])
+    with patch.dict("os.environ", values=PATCHED_ENV, clear=True):
+        result = runner.invoke(
+            main.cli, ["--path", builddir, "graph", "src/", "raw.loc"]
+        )
     assert result.exit_code == 0, result.stdout
 
 
 def test_graph_multiple(builddir):
     """ Test the graph feature with multiple metrics """
     runner = CliRunner()
-    with patch.dict('os.environ', values=PATCHED_ENV, clear=True):
+    with patch.dict("os.environ", values=PATCHED_ENV, clear=True):
         result = runner.invoke(
             main.cli,
             ["--path", builddir, "graph", "src/test.py", "raw.loc", "raw.comments"],
@@ -80,10 +84,19 @@ def test_graph_multiple(builddir):
 def test_graph_multiple_custom_x(builddir):
     """ Test the graph feature with multiple metrics """
     runner = CliRunner()
-    with patch.dict('os.environ', values=PATCHED_ENV, clear=True):
+    with patch.dict("os.environ", values=PATCHED_ENV, clear=True):
         result = runner.invoke(
             main.cli,
-            ["--path", builddir, "graph", "src/test.py", "raw.loc", "raw.comments", "-x", "raw.sloc"],
+            [
+                "--path",
+                builddir,
+                "graph",
+                "src/test.py",
+                "raw.loc",
+                "raw.comments",
+                "-x",
+                "raw.sloc",
+            ],
         )
     assert result.exit_code == 0, result.stdout
 
@@ -91,7 +104,7 @@ def test_graph_multiple_custom_x(builddir):
 def test_graph_multiple_path(builddir):
     """ Test the graph feature with multiple metrics """
     runner = CliRunner()
-    with patch.dict('os.environ', values=PATCHED_ENV, clear=True):
+    with patch.dict("os.environ", values=PATCHED_ENV, clear=True):
         result = runner.invoke(
             main.cli, ["--path", builddir, "graph", "src/", "raw.loc", "raw.comments"]
         )
@@ -101,7 +114,7 @@ def test_graph_multiple_path(builddir):
 def test_graph_output(builddir):
     """ Test the graph feature with target output file """
     runner = CliRunner()
-    with patch.dict('os.environ', values=PATCHED_ENV, clear=True):
+    with patch.dict("os.environ", values=PATCHED_ENV, clear=True):
         result = runner.invoke(
             main.cli,
             [
@@ -122,7 +135,7 @@ def test_graph_output(builddir):
 def test_graph_output_granular(builddir):
     """ Test the graph feature with target output file """
     runner = CliRunner()
-    with patch.dict('os.environ', values=PATCHED_ENV, clear=True):
+    with patch.dict("os.environ", values=PATCHED_ENV, clear=True):
         result = runner.invoke(
             main.cli,
             [

--- a/test/integration/test_report.py
+++ b/test/integration/test_report.py
@@ -57,8 +57,7 @@ def test_report_not_found(builddir):
     """
     runner = CliRunner()
     result = runner.invoke(
-        main.cli,
-        ["--path", builddir, "report", "src/test1.py", "--metrics", "raw.loc"],
+        main.cli, ["--path", builddir, "report", "src/test1.py", "--metrics", "raw.loc"]
     )
     assert result.exit_code == 0, result.stdout
     assert "Not found" in result.stdout

--- a/wily/__main__.py
+++ b/wily/__main__.py
@@ -206,10 +206,10 @@ def diff(ctx, files, metrics, all, detail):
 @click.option(
     "-o", "--output", help="Output report to specified HTML path, e.g. reports/out.html"
 )
+@click.option("-x", "--x-axis", help="Metric to use on x-axis, defaults to history.")
 @click.option(
-    "-x", "--x-axis", help="Metric to use on x-axis, defaults to history."
+    "-a/-c", "--changes/--all", default=True, help="All commits or changes only"
 )
-@click.option("-a/-c", "--changes/--all", default=True, help="All commits or changes only")
 @click.pass_context
 def graph(ctx, path, metrics, output, x_axis, changes):
     """
@@ -234,7 +234,14 @@ def graph(ctx, path, metrics, output, x_axis, changes):
     from wily.commands.graph import graph
 
     logger.debug(f"Running report on {path} for metrics {metrics}")
-    graph(config=config, path=path, metrics=metrics, output=output, x_axis=x_axis, changes=changes)
+    graph(
+        config=config,
+        path=path,
+        metrics=metrics,
+        output=output,
+        x_axis=x_axis,
+        changes=changes,
+    )
 
 
 @cli.command()

--- a/wily/__main__.py
+++ b/wily/__main__.py
@@ -202,12 +202,16 @@ def diff(ctx, files, metrics, all, detail):
 
 @cli.command()
 @click.argument("path", type=click.Path(resolve_path=False))
-@click.argument("metrics", nargs=-1, required=True)
+@click.argument("metrics", nargs=-2, required=True)
 @click.option(
     "-o", "--output", help="Output report to specified HTML path, e.g. reports/out.html"
 )
+@click.option(
+    "-x", "--x-axis", help="Metric to use on x-axis, defaults to history."
+)
+@click.option("-a/-c", "--changes/--all", default=True, help="All commits or changes only")
 @click.pass_context
-def graph(ctx, path, metrics, output):
+def graph(ctx, path, metrics, output, x_axis, changes):
     """
     Graph a specific metric for a given file, if a path is given, all files within path will be graphed.
 
@@ -230,7 +234,7 @@ def graph(ctx, path, metrics, output):
     from wily.commands.graph import graph
 
     logger.debug(f"Running report on {path} for metrics {metrics}")
-    graph(config=config, path=path, metrics=metrics, output=output)
+    graph(config=config, path=path, metrics=metrics, output=output, x_axis=x_axis, changes=changes)
 
 
 @cli.command()

--- a/wily/__main__.py
+++ b/wily/__main__.py
@@ -225,6 +225,9 @@ def graph(ctx, path, metrics, output, x_axis, changes):
 
         $ wily graph src/test.py raw.loc cyclomatic.complexity
 
+    Graph test.py against raw.loc and raw.sloc on the x-axis
+
+        $ wily graph src/test.py raw.loc --x-axis raw.sloc
     """
     config = ctx.obj["CONFIG"]
 

--- a/wily/cache.py
+++ b/wily/cache.py
@@ -29,8 +29,8 @@ def exists(config):
     :rtype: ``boolean``
     """
     exists = (
-            pathlib.Path(config.cache_path).exists()
-            and pathlib.Path(config.cache_path).is_dir()
+        pathlib.Path(config.cache_path).exists()
+        and pathlib.Path(config.cache_path).is_dir()
     )
     if not exists:
         return False

--- a/wily/commands/graph.py
+++ b/wily/commands/graph.py
@@ -36,9 +36,9 @@ def graph(config, path, metrics, output=None, x_axis=None, changes=True, text=Fa
     abs_path = config.path / pathlib.Path(path)
 
     if x_axis is None:
-        x_axis = 'history'
+        x_axis = "history"
     else:
-        x_operator, x_key = x_axis.split('.')
+        x_operator, x_key = x_axis.split(".")
 
     if abs_path.is_dir():
         paths = [
@@ -48,11 +48,11 @@ def graph(config, path, metrics, output=None, x_axis=None, changes=True, text=Fa
         paths = [path]
 
     operator, key = metrics[0].split(".")
-    if len(metrics) == 1: # only y-axis
+    if len(metrics) == 1:  # only y-axis
         z_axis = None
     else:
         z_axis = resolve_metric(metrics[1])
-        z_operator, z_key = metrics[1].split('.')
+        z_operator, z_key = metrics[1].split(".")
     for path in paths:
         x = []
         y = []
@@ -60,19 +60,33 @@ def graph(config, path, metrics, output=None, x_axis=None, changes=True, text=Fa
         labels = []
         last_y = None
         for rev in state.index[state.default_archiver].revisions:
-            labels.append(
-                f"{rev.revision.author_name} <br>{rev.revision.message}"
-            )
+            labels.append(f"{rev.revision.author_name} <br>{rev.revision.message}")
             try:
                 val = rev.get(config, state.default_archiver, operator, str(path), key)
                 if val != last_y or not changes:
                     y.append(val)
                     if z_axis:
-                        z.append(rev.get(config, state.default_archiver, z_operator, str(path), z_key))
-                    if x_axis == 'history':
+                        z.append(
+                            rev.get(
+                                config,
+                                state.default_archiver,
+                                z_operator,
+                                str(path),
+                                z_key,
+                            )
+                        )
+                    if x_axis == "history":
                         x.append(format_datetime(rev.revision.date))
                     else:
-                        x.append(rev.get(config, state.default_archiver, x_operator, str(path), x_key))
+                        x.append(
+                            rev.get(
+                                config,
+                                state.default_archiver,
+                                x_operator,
+                                str(path),
+                                x_key,
+                            )
+                        )
                 last_y = val
             except KeyError:
                 # missing data
@@ -104,7 +118,14 @@ def graph(config, path, metrics, output=None, x_axis=None, changes=True, text=Fa
     y_metric = resolve_metric(metrics[0])
     title = f"{x_axis.capitalize()} of {y_metric.description} for {path}"
     plotly.offline.plot(
-        {"data": data, "layout": go.Layout(title=title, xaxis={"title": x_axis}, yaxis={"title": y_metric.description})},
+        {
+            "data": data,
+            "layout": go.Layout(
+                title=title,
+                xaxis={"title": x_axis},
+                yaxis={"title": y_metric.description},
+            ),
+        },
         auto_open=auto_open,
         filename=filename,
     )

--- a/wily/commands/graph.py
+++ b/wily/commands/graph.py
@@ -13,17 +13,17 @@ from wily.operators import resolve_metric
 from wily.state import State
 
 
-def graph(config, path, metrics, output=None):
+def graph(config, path, metrics, output=None, x_axis=None, changes=True, text=False):
     """
     Graph information about the cache and runtime.
 
     :param config: The configuration.
     :type  config: :class:`wily.config.WilyConfig`
 
-    :param paths: The path(s) to the files.
-    :type  paths: ``list``
+    :param path: The path to the files.
+    :type  path: ``list``
 
-    :param metrics: The metrics to report on.
+    :param metrics: The Y and Z-axis metrics to report on.
     :type  metrics: ``tuple``
 
     :param output: Save report to specified path instead of opening browser.
@@ -35,6 +35,11 @@ def graph(config, path, metrics, output=None):
     state = State(config)
     abs_path = config.path / pathlib.Path(path)
 
+    if x_axis is None:
+        x_axis = 'history'
+    else:
+        x_operator, x_key = x_axis.split('.')
+
     if abs_path.is_dir():
         paths = [
             p.relative_to(config.path) for p in pathlib.Path(abs_path).glob("**/*.py")
@@ -42,53 +47,64 @@ def graph(config, path, metrics, output=None):
     else:
         paths = [path]
 
-    for metric in metrics:
-        operator, key = metric.split(".")
-        metric = resolve_metric(metric)
-        for path in paths:
-            x = []
-            y = []
-            labels = []
-            for archiver in state.archivers:
-                # We have to do it backwards to get the deltas between releases
-                for rev in state.index[archiver].revisions[::-1]:
-                    labels.append(
-                        f"{rev.revision.author_name} <br>{rev.revision.message}"
-                    )
-                    try:
-                        val = rev.get(config, archiver, operator, str(path), key)
-                        y.append(val)
-                    except KeyError:
-                        y.append(0)
-                    finally:
-                        x.append(format_datetime(rev.revision.date))
-            # Create traces
-            trace = go.Scatter(
-                x=x,
-                y=y,
-                mode="lines+markers",
-                name=f"{metric.description} for {path}",
-                ids=state.index[archiver].revision_keys,
-                text=labels,
-                xcalendar="gregorian",
+    operator, key = metrics[0].split(".")
+    if len(metrics) == 1: # only y-axis
+        z_axis = None
+    else:
+        z_axis = resolve_metric(metrics[1])
+        z_operator, z_key = metrics[1].split('.')
+    for path in paths:
+        x = []
+        y = []
+        z = []
+        labels = []
+        last_y = None
+        for rev in state.index[state.default_archiver].revisions:
+            labels.append(
+                f"{rev.revision.author_name} <br>{rev.revision.message}"
             )
-            data.append(trace)
+            try:
+                val = rev.get(config, state.default_archiver, operator, str(path), key)
+                if val != last_y or not changes:
+                    y.append(val)
+                    if z_axis:
+                        z.append(rev.get(config, state.default_archiver, z_operator, str(path), z_key))
+                    if x_axis == 'history':
+                        x.append(format_datetime(rev.revision.date))
+                    else:
+                        x.append(rev.get(config, state.default_archiver, x_operator, str(path), x_key))
+                last_y = val
+            except KeyError:
+                # missing data
+                pass
+
+        # Create traces
+        trace = go.Scatter(
+            x=x,
+            y=y,
+            mode="lines+markers+text" if text else "lines+markers",
+            name=f"{path}",
+            ids=state.index[state.default_archiver].revision_keys,
+            text=labels,
+            marker=dict(
+                size=0 if z_axis is None else z,
+                color=list(range(len(y))),
+                # colorscale='Viridis',
+            ),
+            xcalendar="gregorian",
+            hoveron="points+fills",
+        )
+        data.append(trace)
     if output:
         filename = output
         auto_open = False
     else:
         filename = "wily-report.html"
         auto_open = True
-    if len(metrics) == 1:
-        metric = resolve_metric(metrics[0])
-        title = f"History of {metric.description}"
-    else:
-        descriptions = ", ".join(
-            [resolve_metric(metric).description for metric in metrics]
-        )
-        title = f"History of {descriptions}"
+    y_metric = resolve_metric(metrics[0])
+    title = f"{x_axis.capitalize()} of {y_metric.description} for {path}"
     plotly.offline.plot(
-        {"data": data, "layout": go.Layout(title=title)},
+        {"data": data, "layout": go.Layout(title=title, xaxis={"title": x_axis}, yaxis={"title": y_metric.description})},
         auto_open=auto_open,
         filename=filename,
     )


### PR DESCRIPTION
* Support for configuring the x-axis on the graph command (defaults to history) to a custom metric
* Support for configuring the z-axis (size of bubble on scatter) in graph command by specifying a second metric
* Set metrics to cap at 2 possible options in graph command
* Running the test suite no longer opens 12 browser windows :-)