### PR TITLE
Add Filesystem archiver

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # Release History
 
+## 1.7.0 (tbc)
+
+* Add halstead metrics
+
 ## 1.6.0 (30th November 2018)
 
 **NB: Upgrade will warn about index rebuild, this is expected behaviour**

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,7 +2,10 @@
 
 ## 1.7.0 (tbc)
 
-* Add halstead metrics
+* Add halstead metrics as an optional operator
+* Add an archiver flag to the build command (`-a`)
+* Add a new filesystem archiver as an alternative to the git archiver for when you want to measure changes between files without having to use git.
+* Setup new workflow - if the git archiver fails to initialise, build will default to the filesystem assuming the path is not a git repository.
 
 ## 1.6.0 (30th November 2018)
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -74,11 +74,14 @@ def builddir(gitdir):
     """
     tmppath = pathlib.Path(gitdir)
     runner = CliRunner()
-    result = runner.invoke(
+    result1 = runner.invoke(
         main.cli, ["--debug", "--path", gitdir, "build", str(tmppath / "src")]
     )
-    assert result.exit_code == 0, result.stdout
-    result = runner.invoke(main.cli, ["--debug", "--path", gitdir, "index"])
-    assert result.exit_code == 0, result.stdout
+    assert result1.exit_code == 0, result1.stdout
+
+    result2 = runner.invoke(main.cli, ["--debug", "--path", gitdir, "index"])
+    assert result2.exit_code == 0, result2.stdout
+
+    assert (tmppath / ".wily" / "git").exists()
 
     return gitdir

--- a/test/integration/test_build.py
+++ b/test/integration/test_build.py
@@ -218,7 +218,7 @@ def test_build_no_git_history(tmpdir):
         assert result.exit_code == 1, result.stdout
 
 
-archivers = {archiver.name for archiver in ALL_ARCHIVERS}
+archivers = {name for name in ALL_ARCHIVERS.keys()}
 
 
 @pytest.mark.parametrize("archiver", archivers)

--- a/test/unit/test_archivers.py
+++ b/test/unit/test_archivers.py
@@ -60,7 +60,7 @@ def test_basearchiver():
 
 
 def test_defaults():
-    assert wily.archivers.ARCHIVER_GIT in wily.archivers.ALL_ARCHIVERS
+    assert wily.archivers.ARCHIVER_GIT in wily.archivers.ALL_ARCHIVERS.values()
 
 
 def test_resolve_archiver():

--- a/wily/__main__.py
+++ b/wily/__main__.py
@@ -83,12 +83,18 @@ def cli(ctx, debug, config, path):
     help="List of operators, separated by commas",
 )
 @click.option(
+    "-a",
+    "--archiver",
+    type=click.STRING,
+    help="Archiver to use, defaults to git if git repo, else filesystem",
+)
+@click.option(
     "--skip-gitignore-check/--gitignore-check",
     default=False,
     help="Skip checking of .gitignore for '.wily/'",
 )
 @click.pass_context
-def build(ctx, max_revisions, targets, operators, skip_gitignore_check):
+def build(ctx, max_revisions, targets, operators, skip_gitignore_check, archiver):
     """Build the wily cache."""
     config = ctx.obj["CONFIG"]
 
@@ -101,6 +107,10 @@ def build(ctx, max_revisions, targets, operators, skip_gitignore_check):
     if operators:
         logger.debug(f"Fixing operators to {operators}")
         config.operators = operators.strip().split(",")
+
+    if archiver:
+        logger.debug(f"Fixing archiver to {archiver}")
+        config.archiver = archiver
 
     config.skip_ignore_check = skip_gitignore_check
     logger.debug(f"Fixing targets to {targets}")

--- a/wily/__main__.py
+++ b/wily/__main__.py
@@ -86,6 +86,7 @@ def cli(ctx, debug, config, path):
     "-a",
     "--archiver",
     type=click.STRING,
+    default="git",
     help="Archiver to use, defaults to git if git repo, else filesystem",
 )
 @click.option(

--- a/wily/archivers/__init__.py
+++ b/wily/archivers/__init__.py
@@ -71,7 +71,7 @@ ARCHIVER_FILESYSTEM = Archiver(
 )
 
 """Set of all available archivers"""
-ALL_ARCHIVERS = {ARCHIVER_GIT, ARCHIVER_FILESYSTEM}
+ALL_ARCHIVERS = {a.name: a for a in [ARCHIVER_GIT, ARCHIVER_FILESYSTEM]}
 
 
 def resolve_archiver(name):
@@ -82,8 +82,7 @@ def resolve_archiver(name):
     :type  name: ``str``
     :return: The archiver type
     """
-    r = [archiver for archiver in ALL_ARCHIVERS if archiver.name == name.lower()]
-    if not r:
+    if name not in ALL_ARCHIVERS:
         raise ValueError(f"Resolver {name} not recognised.")
     else:
-        return r[0]
+        return ALL_ARCHIVERS[name.lower()]

--- a/wily/archivers/__init__.py
+++ b/wily/archivers/__init__.py
@@ -40,7 +40,7 @@ class BaseArchiver(object):
 
     def finish(self):
         """Clean up any state if processing completed/failed."""
-        raise NotImplementedError
+        pass
 
 
 @dataclass
@@ -55,6 +55,7 @@ class Revision:
 
 
 from wily.archivers.git import GitArchiver
+from wily.archivers.filesystem import FilesystemArchiver
 
 
 """Type for an operator"""
@@ -64,9 +65,13 @@ Archiver = namedtuple("Archiver", "name cls description")
 """Git Operator defined in `wily.archivers.git`"""
 ARCHIVER_GIT = Archiver(name="git", cls=GitArchiver, description="Git archiver")
 
+"""Filesystem archiver"""
+ARCHIVER_FILESYSTEM = Archiver(
+    name="filesystem", cls=FilesystemArchiver, description="Filesystem archiver"
+)
 
 """Set of all available archivers"""
-ALL_ARCHIVERS = {ARCHIVER_GIT}
+ALL_ARCHIVERS = {ARCHIVER_GIT, ARCHIVER_FILESYSTEM}
 
 
 def resolve_archiver(name):

--- a/wily/archivers/filesystem.py
+++ b/wily/archivers/filesystem.py
@@ -1,0 +1,63 @@
+"""
+Filesystem Archiver.
+
+Implementation of the archiver API for a standard directory (no revisions)
+"""
+import logging
+
+from wily.archivers import BaseArchiver, Revision
+
+logger = logging.getLogger(__name__)
+
+
+class FilesystemArchiver(BaseArchiver):
+    """Basic implementation of the base archiver."""
+
+    name = "filesystem"
+
+    def __init__(self, config):
+        """
+        Instantiate a new Filesystem Archiver.
+
+        :param config: The wily configuration
+        :type  config: :class:`wily.config.WilyConfig`
+        """
+        self.config = config
+
+    def revisions(self, path, max_revisions):
+        """
+        Get the list of revisions.
+
+        :param path: the path to target.
+        :type  path: ``str``
+
+        :param max_revisions: the maximum number of revisions.
+        :type  max_revisions: ``int``
+
+        :return: A list of revisions.
+        :rtype: ``list`` of :class:`Revision`
+        """
+        # TODO : Sha the current file/path
+        # so if the files change, the revision is redundant
+        return [
+            Revision(
+                key="current",
+                author_name="Local User",
+                author_email="-",
+                date="Current",
+                message="None",
+            )
+        ]
+
+    def checkout(self, revision, options):
+        """
+        Checkout a specific revision.
+
+        :param revision: The revision identifier.
+        :type  revision: :class:`Revision`
+
+        :param options: Any additional options.
+        :type  options: ``dict``
+        """
+        # effectively noop since there are no revision
+        pass

--- a/wily/archivers/filesystem.py
+++ b/wily/archivers/filesystem.py
@@ -4,7 +4,9 @@ Filesystem Archiver.
 Implementation of the archiver API for a standard directory (no revisions)
 """
 import logging
-
+import os.path
+from datetime import datetime
+import hashlib
 from wily.archivers import BaseArchiver, Revision
 
 logger = logging.getLogger(__name__)
@@ -37,14 +39,14 @@ class FilesystemArchiver(BaseArchiver):
         :return: A list of revisions.
         :rtype: ``list`` of :class:`Revision`
         """
-        # TODO : Sha the current file/path
-        # so if the files change, the revision is redundant
+        mtime = os.path.getmtime(path)
+        key = hashlib.sha1(str(mtime).encode()).hexdigest()[:7]
         return [
             Revision(
-                key="current",
-                author_name="Local User",
-                author_email="-",
-                date="Current",
+                key=key,
+                author_name="Local User",  # Don't want to leak local data
+                author_email="-",  # as above
+                date=int(mtime),
                 message="None",
             )
         ]

--- a/wily/archivers/git.py
+++ b/wily/archivers/git.py
@@ -18,7 +18,7 @@ gitignore_options = (".wily/", ".wily", ".wily/*", ".wily/**/*")
 
 
 class InvalidGitRepositoryError(Exception):
-    """Error for when a folder is not a git repo"""
+    """Error for when a folder is not a git repo."""
 
     pass
 

--- a/wily/archivers/git.py
+++ b/wily/archivers/git.py
@@ -7,6 +7,7 @@ import logging
 import pathlib
 
 from git import Repo
+import git.exc
 
 from wily.archivers import BaseArchiver, Revision
 
@@ -14,6 +15,12 @@ logger = logging.getLogger(__name__)
 
 """Possible combinations in .gitignore."""
 gitignore_options = (".wily/", ".wily", ".wily/*", ".wily/**/*")
+
+
+class InvalidGitRepositoryError(Exception):
+    """Error for when a folder is not a git repo"""
+
+    pass
 
 
 class DirtyGitRepositoryError(Exception):
@@ -53,7 +60,10 @@ class GitArchiver(BaseArchiver):
         :param config: The wily configuration
         :type  config: :class:`wily.config.WilyConfig`
         """
-        self.repo = Repo(config.path)
+        try:
+            self.repo = Repo(config.path)
+        except git.exc.InvalidGitRepositoryError as e:
+            raise InvalidGitRepositoryError from e
         self.ignore_gitignore = config.skip_ignore_check
         gitignore = pathlib.Path(config.path) / ".gitignore"
         if not gitignore.exists():

--- a/wily/cache.py
+++ b/wily/cache.py
@@ -183,9 +183,9 @@ def list_archivers(config):
     """
     root = pathlib.Path(config.cache_path)
     result = []
-    for archiver in ALL_ARCHIVERS:
-        if (root / archiver.name).exists():
-            result.append(archiver.name)
+    for name in ALL_ARCHIVERS.keys():
+        if (root / name).exists():
+            result.append(name)
     return result
 
 

--- a/wily/state.py
+++ b/wily/state.py
@@ -168,7 +168,7 @@ class Index(object):
     def save(self):
         """Save the index data back to the wily cache."""
         data = [i.asdict() for i in self._revisions.values()]
-        logger.debug(data)
+        logger.debug("Saving data")
         cache.store_archiver_index(self.config, self.archiver, data)
 
 

--- a/wily/state.py
+++ b/wily/state.py
@@ -192,8 +192,8 @@ class State(object):
         if archiver:
             self.archivers = [archiver.name]
         else:
-            raise ValueError("Archiver not specified")
             self.archivers = cache.list_archivers(config)
+        logger.debug(f"Initialised state indexes for archivers {self.archivers}")
         self.config = config
         self.index = {}
         for archiver in self.archivers:

--- a/wily/state.py
+++ b/wily/state.py
@@ -192,6 +192,7 @@ class State(object):
         if archiver:
             self.archivers = [archiver.name]
         else:
+            raise ValueError("Archiver not specified")
             self.archivers = cache.list_archivers(config)
         self.config = config
         self.index = {}


### PR DESCRIPTION
filesystem archiver is the most-basic archiver, if the git archiver is unavailable (i.e. the target path is not a git repository) the build command should fall back to the filesystem archiver.

The expected behaviours are:
- [x] `wily build -a filesystem` should build with filesystem, regardless of `.git` db existence
- [x] `wily build <target>` should use git by default
- [x] `wily buid <target>` should use filesystem archiver (and tell user) if GitArchiver fails to initialise because of lack of `.git` database
- [x] `wily report`, `wily diff` should work as with the existing git archiver
- [x] `wily diff` should ignore the revision.

Outstanding question:
 - If the user runs `wily build -a filesystem` and changes the files, then runs it again - what should happen? For git, it would fail with a "Dirty repository error" to avoid losing unrevisioned changes. For filesystem, I think it should use the last changed date of the files?