### PR TITLE
change operators set to a dictionary to speed up the lookup functions

### DIFF
--- a/wily/commands/list_metrics.py
+++ b/wily/commands/list_metrics.py
@@ -11,8 +11,8 @@ from wily.operators import ALL_OPERATORS
 
 def list_metrics():
     """List metrics available."""
-    for operator in ALL_OPERATORS:
-        print(f"{operator.name} operator:")
+    for name, operator in ALL_OPERATORS.items():
+        print(f"{name} operator:")
         if len(operator.cls.metrics) > 0:
             print(
                 tabulate.tabulate(

--- a/wily/operators/__init__.py
+++ b/wily/operators/__init__.py
@@ -106,12 +106,15 @@ OPERATOR_HALSTEAD = Operator(
 )
 
 
-"""Set of all available operators."""
+"""Dictionary of all operators"""
 ALL_OPERATORS = {
-    OPERATOR_CYCLOMATIC,
-    OPERATOR_MAINTAINABILITY,
-    OPERATOR_RAW,
-    OPERATOR_HALSTEAD,
+    operator.name: operator
+    for operator in {
+        OPERATOR_CYCLOMATIC,
+        OPERATOR_MAINTAINABILITY,
+        OPERATOR_RAW,
+        OPERATOR_HALSTEAD,
+    }
 }
 
 
@@ -122,11 +125,10 @@ def resolve_operator(name):
     :param name: The name of the operator
     :return: The operator type
     """
-    r = [operator for operator in ALL_OPERATORS if operator.name == name.lower()]
-    if not r or len(r) == 0:
-        raise ValueError(f"Operator {name} not recognised.")
+    if name.lower() in ALL_OPERATORS:
+        return ALL_OPERATORS[name.lower()]
     else:
-        return r[0]
+        raise ValueError(f"Operator {name} not recognised.")
 
 
 def resolve_operators(operators):


### PR DESCRIPTION
The `ALL_OPERATORS` constant is a set in 1.6.0. 

Every lookup to resolve an operator from a string to an operator type results in iteration over the set.

It makes more sense to have ALL_OPERATORS as a dictionary with the name as the key so that lookups are O(1) instead of O(n)