### PR TITLE
Multithreaded builds

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.7.0 (tbc)
+## 1.7.0 (12th December 2018)
 
 * Add halstead metrics as an optional operator
 * Add an archiver flag to the build command (`-a`)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,7 @@
 # Release History
 
+# 1.8.0 (tb)
+
 ## 1.7.0 (12th December 2018)
 
 * Add halstead metrics as an optional operator

--- a/wily/__init__.py
+++ b/wily/__init__.py
@@ -7,7 +7,7 @@ import colorlog
 import datetime
 
 
-__version__ = "1.7.0.dev"
+__version__ = "1.7.0"
 
 _handler = colorlog.StreamHandler()
 _handler.setFormatter(colorlog.ColoredFormatter("%(log_color)s%(message)s"))

--- a/wily/commands/build.py
+++ b/wily/commands/build.py
@@ -17,7 +17,7 @@ from wily.archivers import FilesystemArchiver
 def run_operator(operator, revision, config):
     instance = operator.cls(config)
     logger.debug(f"Running {operator.name} operator on {revision.key}")
-    return instance.run(revision, config)
+    return operator.name, instance.run(revision, config)
 
 
 def build(config, archiver, operators):
@@ -75,11 +75,11 @@ def build(config, archiver, operators):
 
                 stats = {"operator_data": {}}
 
-                bar.next()
                 data = pool.starmap(run_operator, [(operator, revision, config) for operator in operators])
-                logger.debug(data)
-
-                # stats["operator_data"][operator.name] = operator.run(revision, config)
+                
+                for operator_name, result in data:
+                    bar.next()
+                    stats["operator_data"][operator_name] = result
 
                 ir = index.add(revision, operators=operators)
                 ir.store(config, archiver, stats)

--- a/wily/commands/build.py
+++ b/wily/commands/build.py
@@ -15,6 +15,7 @@ from wily.archivers import FilesystemArchiver
 
 
 def run_operator(operator, revision, config):
+    """The function for the multiprocessing pool."""
     instance = operator.cls(config)
     logger.debug(f"Running {operator.name} operator on {revision.key}")
     return operator.name, instance.run(revision, config)

--- a/wily/commands/build.py
+++ b/wily/commands/build.py
@@ -62,7 +62,7 @@ def build(config, archiver, operators):
     bar = Bar("Processing", max=len(revisions) * len(operators))
     state.operators = operators
     try:
-        pool = multiprocessing.pool.Pool(processes=len(operators))
+        pool = multiprocessing.Pool(processes=len(operators))
         for revision in revisions:
             # Checkout target revision
             archiver.checkout(revision, config.checkout_options)

--- a/wily/commands/build.py
+++ b/wily/commands/build.py
@@ -75,8 +75,11 @@ def build(config, archiver, operators):
                 stats = {"operator_data": {}}
 
                 # Run each operator as a seperate process
-                data = pool.starmap(run_operator, [(operator, revision, config) for operator in operators])
-                
+                data = pool.starmap(
+                    run_operator,
+                    [(operator, revision, config) for operator in operators],
+                )
+
                 # Map the data back into a dictionary
                 for operator_name, result in data:
                     bar.next()

--- a/wily/commands/build.py
+++ b/wily/commands/build.py
@@ -72,11 +72,12 @@ def build(config, archiver, operators):
             for revision in revisions:
                 # Checkout target revision
                 archiver.checkout(revision, config.checkout_options)
-
                 stats = {"operator_data": {}}
 
+                # Run each operator as a seperate process
                 data = pool.starmap(run_operator, [(operator, revision, config) for operator in operators])
                 
+                # Map the data back into a dictionary
                 for operator_name, result in data:
                     bar.next()
                     stats["operator_data"][operator_name] = result

--- a/wily/commands/build.py
+++ b/wily/commands/build.py
@@ -15,7 +15,7 @@ from wily.archivers import FilesystemArchiver
 
 
 def run_operator(operator, revision, config):
-    """The function for the multiprocessing pool."""
+    """Run an operator for the multiprocessing pool. Not called directly."""
     instance = operator.cls(config)
     logger.debug(f"Running {operator.name} operator on {revision.key}")
     return operator.name, instance.run(revision, config)


### PR DESCRIPTION
Uses `multiprocessing` to create a process pool for each of the operators, once a revision has been checked out using the archiver, the operator harvesters are run in parallel.

In testing this leads to around a 60% reduction in time to build using the default operators (3).