### PR TITLE
Aggregate directories

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,7 @@
 ## 1.8.0 (master)
 
 * Build process is now run with a multiprocess pool, build times are 50-70% faster (depending on number of operators)
+* Build process will now create a stub for each directory so you can run report on any directory and it will give you aggregate metrics. Each metric specifies it's own aggregation function.
 
 ## 1.7.0 (12th December 2018)
 

--- a/test/integration/test_build.py
+++ b/test/integration/test_build.py
@@ -5,7 +5,6 @@ All of the following tests will use a click CLI runner to fully simulate the CLI
 Many of the tests will depend on a "builddir" fixture which is a compiled wily cache.
 
 TODO : Test build + build with extra operator
-TODO : Test build specific (non-default) operator and wily report
 """
 import pathlib
 import pytest

--- a/test/integration/test_report.py
+++ b/test/integration/test_report.py
@@ -11,7 +11,7 @@ def test_report_no_cache(tmpdir):
 
 def test_report(builddir):
     """
-    Test that report works with a build
+    Test that report works with a build and a specific metric
     """
     runner = CliRunner()
     result = runner.invoke(
@@ -31,7 +31,7 @@ def test_report(builddir):
 
 def test_report_granular(builddir):
     """
-    Test that report works with a build
+    Test that report works with a build against specific metrics and a function
     """
     runner = CliRunner()
     result = runner.invoke(
@@ -64,7 +64,7 @@ def test_report_not_found(builddir):
 
 def test_report_default_metrics(builddir):
     """
-    Test that report works with a build
+    Test that report works with default metrics
     """
     runner = CliRunner()
     result = runner.invoke(main.cli, ["--path", builddir, "report", "src/test.py"])
@@ -72,9 +72,19 @@ def test_report_default_metrics(builddir):
     assert "Not found" not in result.stdout
 
 
+def test_report_path(builddir):
+    """
+    Test that report with a path to a folder (aggregate values)
+    """
+    runner = CliRunner()
+    result = runner.invoke(main.cli, ["--path", builddir, "report", "src"])
+    assert result.exit_code == 0, result.stdout
+    assert "Not found" not in result.stdout
+
+
 def test_report_with_message(builddir):
     """
-    Test that report works with a build
+    Test that report works messages in UI
     """
     runner = CliRunner()
     result = runner.invoke(

--- a/wily/archivers/git.py
+++ b/wily/archivers/git.py
@@ -135,3 +135,4 @@ class GitArchiver(BaseArchiver):
         For git, will checkout HEAD on the original branch when finishing
         """
         self.repo.git.checkout(self.current_branch)
+        self.repo.close()

--- a/wily/commands/build.py
+++ b/wily/commands/build.py
@@ -95,7 +95,7 @@ def build(config, archiver, operators):
                     
                     for root in roots:
                         # find all matching entries recursively
-                        aggregates = [path for path in result.keys() if pathlib.Path(path).match(root + "/**/*")]
+                        aggregates = [path for path in result.keys() if pathlib.Path(path).match(str(root) + "/**/*")]
                     
                         # aggregate values
                         for metric in resolve_operator(operator_name).cls.metrics:

--- a/wily/commands/build.py
+++ b/wily/commands/build.py
@@ -4,6 +4,7 @@ Builds a cache based on a source-control history.
 TODO : Convert .gitignore to radon ignore patterns to make the build more efficient.
 
 """
+import pathlib
 import multiprocessing
 from progress.bar import Bar
 

--- a/wily/commands/build.py
+++ b/wily/commands/build.py
@@ -97,7 +97,7 @@ def build(config, archiver, operators):
                     for root in roots:
                         # find all matching entries recursively
                         aggregates = [path for path in result.keys() if pathlib.Path(path).match(root + "/**/*")]
-                    
+                        stats["operator_data"][root] = {}
                         # aggregate values
                         for metric in resolve_operator(operator_name).cls.metrics:
                             func = metric.aggregate

--- a/wily/commands/build.py
+++ b/wily/commands/build.py
@@ -14,6 +14,7 @@ from wily.state import State
 from wily.archivers.git import InvalidGitRepositoryError
 from wily.archivers import FilesystemArchiver
 
+from wily.operators import resolve_operator
 
 def run_operator(operator, revision, config):
     """Run an operator for the multiprocessing pool. Not called directly."""

--- a/wily/commands/build.py
+++ b/wily/commands/build.py
@@ -97,13 +97,13 @@ def build(config, archiver, operators):
                     for root in roots:
                         # find all matching entries recursively
                         aggregates = [path for path in result.keys() if pathlib.Path(path).match(root + "/**/*")]
-                        stats["operator_data"][root] = {}
+                        result[root] = {}
                         # aggregate values
                         for metric in resolve_operator(operator_name).cls.metrics:
                             func = metric.aggregate
                             values = [result[aggregate][metric.name] for aggregate in aggregates]
                             if len(values) > 0:
-                                stats["operator_data"][root][metric] = func(values)
+                                result[root][metric.name] = func(values)
 
                     stats["operator_data"][operator_name] = result
                     bar.next()

--- a/wily/commands/build.py
+++ b/wily/commands/build.py
@@ -101,7 +101,7 @@ def build(config, archiver, operators):
                         # aggregate values
                         for metric in resolve_operator(operator_name).cls.metrics:
                             func = metric.aggregate
-                            values = [result[aggregate] for aggregate in aggregates]
+                            values = [result[aggregate][metric.name] for aggregate in aggregates]
                             stats["operator_data"][root][metric] = func(values)
 
                     stats["operator_data"][operator_name] = result

--- a/wily/commands/build.py
+++ b/wily/commands/build.py
@@ -92,18 +92,18 @@ def build(config, archiver, operators):
                     for entry in result.keys():
                         parent = pathlib.Path(entry).parents[0]
                         if parent not in roots:
-                            roots.append(str(parent))
+                            roots.append(parent)
                     
                     for root in roots:
                         # find all matching entries recursively
-                        aggregates = [path for path in result.keys() if pathlib.Path(path).match(root + "/**/*")]
-                        result[root] = {}
+                        aggregates = [path for path in result.keys() if root in pathlib.Path(path).parents]
+                        result[str(root)] = {}
                         # aggregate values
                         for metric in resolve_operator(operator_name).cls.metrics:
                             func = metric.aggregate
                             values = [result[aggregate][metric.name] for aggregate in aggregates]
                             if len(values) > 0:
-                                result[root][metric.name] = func(values)
+                                result[str(root)][metric.name] = func(values)
 
                     stats["operator_data"][operator_name] = result
                     bar.next()

--- a/wily/commands/build.py
+++ b/wily/commands/build.py
@@ -102,7 +102,8 @@ def build(config, archiver, operators):
                         for metric in resolve_operator(operator_name).cls.metrics:
                             func = metric.aggregate
                             values = [result[aggregate][metric.name] for aggregate in aggregates]
-                            stats["operator_data"][root][metric] = func(values)
+                            if len(values) > 0:
+                                stats["operator_data"][root][metric] = func(values)
 
                     stats["operator_data"][operator_name] = result
                     bar.next()

--- a/wily/commands/build.py
+++ b/wily/commands/build.py
@@ -16,6 +16,7 @@ from wily.archivers import FilesystemArchiver
 
 from wily.operators import resolve_operator
 
+
 def run_operator(operator, revision, config):
     """Run an operator for the multiprocessing pool. Not called directly."""
     instance = operator.cls(config)
@@ -93,15 +94,22 @@ def build(config, archiver, operators):
                         parent = pathlib.Path(entry).parents[0]
                         if parent not in roots:
                             roots.append(parent)
-                    
+
                     for root in roots:
                         # find all matching entries recursively
-                        aggregates = [path for path in result.keys() if root in pathlib.Path(path).parents]
+                        aggregates = [
+                            path
+                            for path in result.keys()
+                            if root in pathlib.Path(path).parents
+                        ]
                         result[str(root)] = {}
                         # aggregate values
                         for metric in resolve_operator(operator_name).cls.metrics:
                             func = metric.aggregate
-                            values = [result[aggregate][metric.name] for aggregate in aggregates]
+                            values = [
+                                result[aggregate][metric.name]
+                                for aggregate in aggregates
+                            ]
                             if len(values) > 0:
                                 result[str(root)][metric.name] = func(values)
 

--- a/wily/commands/build.py
+++ b/wily/commands/build.py
@@ -92,11 +92,11 @@ def build(config, archiver, operators):
                     for entry in result.keys():
                         parent = pathlib.Path(entry).parents[0]
                         if parent not in roots:
-                            roots.append(parent)
+                            roots.append(str(parent))
                     
                     for root in roots:
                         # find all matching entries recursively
-                        aggregates = [path for path in result.keys() if pathlib.Path(path).match(str(root) + "/**/*")]
+                        aggregates = [path for path in result.keys() if pathlib.Path(path).match(root + "/**/*")]
                     
                         # aggregate values
                         for metric in resolve_operator(operator_name).cls.metrics:

--- a/wily/commands/build.py
+++ b/wily/commands/build.py
@@ -84,7 +84,7 @@ def build(config, archiver, operators):
                 for operator_name, result in data:
                     bar.next()
                     stats["operator_data"][operator_name] = result
-
+                logger.debug(list(stats["operator_data"][operator_name].keys()))
                 ir = index.add(revision, operators=operators)
                 ir.store(config, archiver, stats)
         index.save()

--- a/wily/operators/__init__.py
+++ b/wily/operators/__init__.py
@@ -12,7 +12,7 @@ class MetricType(Enum):
     Informational = 3  # Doesn't matter
 
 
-Metric = namedtuple("Metric", "name description type measure")
+Metric = namedtuple("Metric", "name description type measure aggregate")
 
 GOOD_COLORS = {
     MetricType.AimHigh: 32,

--- a/wily/operators/cyclomatic.py
+++ b/wily/operators/cyclomatic.py
@@ -3,6 +3,7 @@ Cyclomatic complexity metric for each function/method.
 
 Provided by the radon library.
 """
+import statistics
 
 import radon
 import radon.cli.harvest as harvesters
@@ -27,7 +28,7 @@ class CyclomaticComplexityOperator(BaseOperator):
         "order": radon.complexity.SCORE,
     }
 
-    metrics = (Metric("complexity", "Cyclomatic Complexity", float, MetricType.AimLow),)
+    metrics = (Metric("complexity", "Cyclomatic Complexity", float, MetricType.AimLow, statistics.mean),)
 
     default_metric_index = 0  # MI
 

--- a/wily/operators/cyclomatic.py
+++ b/wily/operators/cyclomatic.py
@@ -28,7 +28,15 @@ class CyclomaticComplexityOperator(BaseOperator):
         "order": radon.complexity.SCORE,
     }
 
-    metrics = (Metric("complexity", "Cyclomatic Complexity", float, MetricType.AimLow, statistics.mean),)
+    metrics = (
+        Metric(
+            "complexity",
+            "Cyclomatic Complexity",
+            float,
+            MetricType.AimLow,
+            statistics.mean,
+        ),
+    )
 
     default_metric_index = 0  # MI
 

--- a/wily/operators/halstead.py
+++ b/wily/operators/halstead.py
@@ -30,7 +30,9 @@ class HalsteadOperator(BaseOperator):
         Metric("h2", "h2 metric", int, MetricType.AimLow, sum),
         Metric("N1", "N1 metric", int, MetricType.AimLow, sum),
         Metric("N2", "N2 metric", int, MetricType.AimLow, sum),
-        Metric("vocabulary", "Unique vocabulary (h1 + h2)", int, MetricType.AimLow, sum),
+        Metric(
+            "vocabulary", "Unique vocabulary (h1 + h2)", int, MetricType.AimLow, sum
+        ),
         Metric("length", "Length of application", int, MetricType.AimLow, sum),
         Metric("volume", "Code volume", float, MetricType.AimLow, sum),
         Metric("difficulity", "Difficulty", float, MetricType.AimLow, sum),

--- a/wily/operators/halstead.py
+++ b/wily/operators/halstead.py
@@ -35,7 +35,7 @@ class HalsteadOperator(BaseOperator):
         ),
         Metric("length", "Length of application", int, MetricType.AimLow, sum),
         Metric("volume", "Code volume", float, MetricType.AimLow, sum),
-        Metric("difficulity", "Difficulty", float, MetricType.AimLow, sum),
+        Metric("difficulty", "Difficulty", float, MetricType.AimLow, sum),
         Metric("effort", "Effort", float, MetricType.AimLow, sum),
     )
 
@@ -91,4 +91,5 @@ class HalsteadOperator(BaseOperator):
             "volume": report.volume,
             "length": report.length,
             "effort": report.effort,
+            "difficulty": report.difficulty,
         }

--- a/wily/operators/halstead.py
+++ b/wily/operators/halstead.py
@@ -26,15 +26,15 @@ class HalsteadOperator(BaseOperator):
     }
 
     metrics = (
-        Metric("h1", "h1 metric", int, MetricType.AimLow),
-        Metric("h2", "h2 metric", int, MetricType.AimLow),
-        Metric("N1", "N1 metric", int, MetricType.AimLow),
-        Metric("N2", "N2 metric", int, MetricType.AimLow),
-        Metric("vocabulary", "Unique vocabulary (h1 + h2)", int, MetricType.AimLow),
-        Metric("length", "Length of application", int, MetricType.AimLow),
-        Metric("volume", "Code volume", float, MetricType.AimLow),
-        Metric("difficulity", "Difficulty", float, MetricType.AimLow),
-        Metric("effort", "Effort", float, MetricType.AimLow),
+        Metric("h1", "h1 metric", int, MetricType.AimLow, sum),
+        Metric("h2", "h2 metric", int, MetricType.AimLow, sum),
+        Metric("N1", "N1 metric", int, MetricType.AimLow, sum),
+        Metric("N2", "N2 metric", int, MetricType.AimLow, sum),
+        Metric("vocabulary", "Unique vocabulary (h1 + h2)", int, MetricType.AimLow, sum),
+        Metric("length", "Length of application", int, MetricType.AimLow, sum),
+        Metric("volume", "Code volume", float, MetricType.AimLow, sum),
+        Metric("difficulity", "Difficulty", float, MetricType.AimLow, sum),
+        Metric("effort", "Effort", float, MetricType.AimLow, sum),
     )
 
     default_metric_index = 0  # MI

--- a/wily/operators/maintainability.py
+++ b/wily/operators/maintainability.py
@@ -27,8 +27,16 @@ class MaintainabilityIndexOperator(BaseOperator):
     }
 
     metrics = (
-        Metric("rank", "Maintainability Ranking", str, MetricType.Informational, statistics.median),
-        Metric("mi", "Maintainability Index", float, MetricType.AimLow, statistics.mean),
+        Metric(
+            "rank",
+            "Maintainability Ranking",
+            str,
+            MetricType.Informational,
+            statistics.median,
+        ),
+        Metric(
+            "mi", "Maintainability Index", float, MetricType.AimLow, statistics.mean
+        ),
     )
 
     default_metric_index = 1  # MI

--- a/wily/operators/maintainability.py
+++ b/wily/operators/maintainability.py
@@ -3,6 +3,8 @@ Maintainability operator.
 
 Measures the "maintainability" using the Halstead index.
 """
+import statistics
+
 import radon.cli.harvest as harvesters
 from radon.cli import Config
 
@@ -25,8 +27,8 @@ class MaintainabilityIndexOperator(BaseOperator):
     }
 
     metrics = (
-        Metric("rank", "Maintainability Ranking", str, MetricType.Informational),
-        Metric("mi", "Maintainability Index", float, MetricType.AimLow),
+        Metric("rank", "Maintainability Ranking", str, MetricType.Informational, statistics.median),
+        Metric("mi", "Maintainability Index", float, MetricType.AimLow, statistics.mean),
     )
 
     default_metric_index = 1  # MI

--- a/wily/operators/maintainability.py
+++ b/wily/operators/maintainability.py
@@ -32,7 +32,7 @@ class MaintainabilityIndexOperator(BaseOperator):
             "Maintainability Ranking",
             str,
             MetricType.Informational,
-            statistics.median,
+            statistics.mode,
         ),
         Metric(
             "mi", "Maintainability Index", float, MetricType.AimLow, statistics.mean

--- a/wily/operators/raw.py
+++ b/wily/operators/raw.py
@@ -16,14 +16,14 @@ class RawMetricsOperator(BaseOperator):
     name = "raw"
     defaults = {"exclude": None, "ignore": None, "summary": False}
     metrics = (
-        Metric("loc", "Lines of Code", int, MetricType.Informational),
-        Metric("lloc", "L Lines of Code", int, MetricType.AimLow),
-        Metric("sloc", "S Lines of Code", int, MetricType.AimLow),
-        Metric("comments", "Multi-line comments", int, MetricType.AimHigh),
-        Metric("multi", "Multi lines", int, MetricType.Informational),
-        Metric("blank", "blank lines", int, MetricType.Informational),
+        Metric("loc", "Lines of Code", int, MetricType.Informational, sum),
+        Metric("lloc", "L Lines of Code", int, MetricType.AimLow, sum),
+        Metric("sloc", "S Lines of Code", int, MetricType.AimLow, sum),
+        Metric("comments", "Multi-line comments", int, MetricType.AimHigh, sum),
+        Metric("multi", "Multi lines", int, MetricType.Informational, sum),
+        Metric("blank", "blank lines", int, MetricType.Informational, sum),
         Metric(
-            "single_comments", "Single comment lines", int, MetricType.Informational
+            "single_comments", "Single comment lines", int, MetricType.Informational, sum
         ),
     )
     default_metric_index = 0  # LOC

--- a/wily/operators/raw.py
+++ b/wily/operators/raw.py
@@ -23,7 +23,11 @@ class RawMetricsOperator(BaseOperator):
         Metric("multi", "Multi lines", int, MetricType.Informational, sum),
         Metric("blank", "blank lines", int, MetricType.Informational, sum),
         Metric(
-            "single_comments", "Single comment lines", int, MetricType.Informational, sum
+            "single_comments",
+            "Single comment lines",
+            int,
+            MetricType.Informational,
+            sum,
         ),
     )
     default_metric_index = 0  # LOC


### PR DESCRIPTION
Once the build has completed, each revision should store the metrics at a directory level:

- Feature is enabled by default
- If user does `wily report <path>` and the path is a directory, it should show those metrics
- `wily graph` should continue to do recursive file searches for now, perhaps later that can be a feature toggle
- Metric should explicitly state how the aggregate value is calculated. Some, e.g. MI are median, volume, vocab, h1, h2 would all be `sum()` and rankings would be `median`.