### PR TITLE
Dynamic cache location

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,6 +1,7 @@
 import pathlib
 from textwrap import dedent
-
+import os
+import tempfile
 import pytest
 from click.testing import CliRunner
 from git import Repo, Actor
@@ -82,6 +83,8 @@ def builddir(gitdir):
     result2 = runner.invoke(main.cli, ["--debug", "--path", gitdir, "index"])
     assert result2.exit_code == 0, result2.stdout
 
-    assert (tmppath / ".wily" / "git").exists()
-
     return gitdir
+
+
+def pytest_runtest_setup(item):
+    os.environ['HOME'] = tempfile.gettempdir()

--- a/wily/__main__.py
+++ b/wily/__main__.py
@@ -1,8 +1,6 @@
 # -*- coding: UTF-8 -*-
 """Main command line."""
 
-import os.path
-
 import click
 
 from wily import logger, __version__

--- a/wily/__main__.py
+++ b/wily/__main__.py
@@ -8,7 +8,7 @@ import click
 from wily import logger, __version__
 from wily.archivers import resolve_archiver
 from wily.cache import exists, get_default_metrics
-from wily.config import DEFAULT_CONFIG_PATH, DEFAULT_CACHE_PATH
+from wily.config import DEFAULT_CONFIG_PATH
 from wily.config import load as load_config
 from wily.decorators import add_version
 from wily.operators import resolve_operators
@@ -71,7 +71,6 @@ def cli(ctx, debug, config, path):
     if path:
         logger.debug(f"Fixing path to {path}")
         ctx.obj["CONFIG"].path = path
-        ctx.obj["CONFIG"].cache_path = os.path.join(path, DEFAULT_CACHE_PATH)
     logger.debug(f"Loaded configuration from {config}")
 
 

--- a/wily/archivers/filesystem.py
+++ b/wily/archivers/filesystem.py
@@ -5,7 +5,6 @@ Implementation of the archiver API for a standard directory (no revisions)
 """
 import logging
 import os.path
-from datetime import datetime
 import hashlib
 from wily.archivers import BaseArchiver, Revision
 

--- a/wily/config.py
+++ b/wily/config.py
@@ -23,6 +23,9 @@ def generate_cache_path(path):
     """
     Generate the cache path
     """
+    wily_home = pathlib.Path.home() / ".wily"
+    if not wily_home.exists() and not wily_home.is_dir():
+        wily_home.mkdir()
     sha = hashlib.sha1(str(path).encode()).hexdigest()[:7]
     cache_path = pathlib.Path.home() / ".wily" / sha
     return str(cache_path)

--- a/wily/config.py
+++ b/wily/config.py
@@ -26,7 +26,7 @@ def generate_cache_path(path):
     wily_home = pathlib.Path.home() / ".wily"
     if not wily_home.exists() and not wily_home.is_dir():
         wily_home.mkdir()
-    sha = hashlib.sha1(str(path).encode()).hexdigest()[:7]
+    sha = hashlib.sha1(str(path).encode()).hexdigest()
     cache_path = pathlib.Path.home() / ".wily" / sha
     return str(cache_path)
 
@@ -44,7 +44,6 @@ class WilyConfig(object):
     path: str
     max_revisions: int
     skip_ignore_check: bool = False
-    cache_path: str = None
     targets: List[str] = None
     checkout_options: dict = field(default_factory=dict)
 
@@ -52,8 +51,10 @@ class WilyConfig(object):
         """Clone targets as a list of path."""
         if self.targets is None or "":
             self.targets = [self.path]
-        abs_path = pathlib.Path(self.path).absolute()
-        self.cache_path = generate_cache_path(abs_path)
+
+    @property
+    def cache_path(self):
+        return generate_cache_path(pathlib.Path(self.path).absolute())
 
 
 # Default values for Wily

--- a/wily/config.py
+++ b/wily/config.py
@@ -9,6 +9,7 @@ TODO : Better utilise default values and factory in @dataclass to replace DEFAUL
 import configparser
 import logging
 import pathlib
+import hashlib
 from dataclasses import dataclass, field
 from typing import Any, List
 
@@ -17,8 +18,14 @@ from wily.archivers import ARCHIVER_GIT
 
 logger = logging.getLogger(__name__)
 
-""" The default path name to the cache """
-DEFAULT_CACHE_PATH = ".wily"
+
+def generate_cache_path(path):
+    """
+    Generate the cache path
+    """
+    sha = hashlib.sha1(str(path).encode()).hexdigest()[:7]
+    cache_path = pathlib.Path.home() / ".wily" / sha
+    return str(cache_path)
 
 
 @dataclass
@@ -34,7 +41,7 @@ class WilyConfig(object):
     path: str
     max_revisions: int
     skip_ignore_check: bool = False
-    cache_path: str = DEFAULT_CACHE_PATH
+    cache_path: str = None
     targets: List[str] = None
     checkout_options: dict = field(default_factory=dict)
 
@@ -42,6 +49,8 @@ class WilyConfig(object):
         """Clone targets as a list of path."""
         if self.targets is None or "":
             self.targets = [self.path]
+        abs_path = pathlib.Path(self.path).absolute()
+        self.cache_path = generate_cache_path(abs_path)
 
 
 # Default values for Wily


### PR DESCRIPTION
Change the basic assumption in wily that the cache folder should be within the path specified.
Instead create a path inside the $HOME directory. This will reduce the most annoying setup step of having to add .wily to the .gitignore
Must work on Windows + Linux