### PR TITLE
update release notes and enable halstead by default

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,11 @@
 # Release History
 
-## 1.9.0 (master)
+## 1.10.0
+
+* Report command now has the ability to generate HTML reports with the `-f HTML` option @DahlitzFlorian
+* Halstead metrics enabled by default
+
+## 1.9.0 (28th December 2018)
 
 * Wily now supports Windows! Full test suite works on Windows, Mac OS and Linux
 * Wily no longer puts the .wily cache in the target path, cache is now stored in the $HOME path. This means you no longer need to add .wily to .gitignore before running a build. Wily will isolate cache folders based on the absolute path

--- a/wily/__init__.py
+++ b/wily/__init__.py
@@ -7,7 +7,7 @@ import colorlog
 import datetime
 
 
-__version__ = "1.9.0"
+__version__ = "1.10.0"
 
 _handler = colorlog.StreamHandler()
 _handler.setFormatter(colorlog.ColoredFormatter("%(log_color)s%(message)s"))

--- a/wily/config.py
+++ b/wily/config.py
@@ -80,6 +80,7 @@ DEFAULT_OPERATORS = {
     operators.OPERATOR_RAW.name,
     operators.OPERATOR_MAINTAINABILITY.name,
     operators.OPERATOR_CYCLOMATIC.name,
+    operators.OPERATOR_HALSTEAD.name,
 }
 
 """ The name of the default archiver """

--- a/wily/operators/halstead.py
+++ b/wily/operators/halstead.py
@@ -26,10 +26,10 @@ class HalsteadOperator(BaseOperator):
     }
 
     metrics = (
-        Metric("h1", "h1 metric", int, MetricType.AimLow, sum),
-        Metric("h2", "h2 metric", int, MetricType.AimLow, sum),
-        Metric("N1", "N1 metric", int, MetricType.AimLow, sum),
-        Metric("N2", "N2 metric", int, MetricType.AimLow, sum),
+        Metric("h1", "Unique Operands", int, MetricType.AimLow, sum),
+        Metric("h2", "Unique Operators", int, MetricType.AimLow, sum),
+        Metric("N1", "Number of Operands", int, MetricType.AimLow, sum),
+        Metric("N2", "Number of Operators", int, MetricType.AimLow, sum),
         Metric(
             "vocabulary", "Unique vocabulary (h1 + h2)", int, MetricType.AimLow, sum
         ),


### PR DESCRIPTION
Enable halstead metrics by default and prep 1.10.0 release