### PR TITLE
Fix halstead harvester for errors thrown by radon

### DIFF
--- a/wily/operators/halstead.py
+++ b/wily/operators/halstead.py
@@ -78,6 +78,11 @@ class HalsteadOperator(BaseOperator):
                         function, report = item
                         results[filename][function] = self._report_to_dict(report)
                 else:
+                    if isinstance(instance, str) and instance == "error":
+                        logger.warning(
+                            f"Failed to run Halstead harvester on {filename} : {details['error']}"
+                        )
+                        continue
                     results[filename] = self._report_to_dict(instance)
         return results
 


### PR DESCRIPTION
Similar to the fix for cyclomatic complexity here:
7ba461c8f7f977a9fae1d3a52a35c8c139cff161

the radon halstead harvester can return errors as a piece of data and we
need to log it rather than attempt to add it to our report.