### PR TITLE
[WIP] Allow setting threshold for diff in order to use via CI

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,8 +1,8 @@
 import pathlib
-from textwrap import dedent
-import os
 import shutil
 import tempfile
+from textwrap import dedent
+
 import pytest
 from click.testing import CliRunner
 from git import Repo, Actor
@@ -94,3 +94,18 @@ def cache_path(monkeypatch):
     monkeypatch.setenv("HOME", tmp)
     yield tmp
     shutil.rmtree(tmp)
+
+
+@pytest.fixture
+def simple_test():
+    return dedent(
+        """
+            import abc
+            foo = 1
+            def function1():
+                pass
+            class Class1(object):
+                def method(self):
+                    pass
+            """
+    )

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -98,6 +98,9 @@ def cache_path(monkeypatch):
 
 @pytest.fixture
 def simple_test():
+    """
+    Return a simple code structure for test reusability.
+    """
     return dedent(
         """
             import abc

--- a/test/integration/test_diff.py
+++ b/test/integration/test_diff.py
@@ -95,21 +95,9 @@ def test_diff_output_more_complex(builddir):
     assert "- ->" not in result.stdout
 
 
-def test_diff_output_less_complex(builddir):
+def test_diff_output_less_complex(builddir, simple_test):
     """ Test the diff feature by making the test file more complicated """
-
-    simple_test = """
-            import abc
-            foo = 1
-            def function1():
-                pass
-            class Class1(object):
-                def method(self):
-                    pass
-            """
-
-    with open(pathlib.Path(builddir) / "src" / "test.py", "w") as test_py:
-        test_py.write(dedent(simple_test))
+    (pathlib.Path(builddir) / "src" / "test.py").write_text(simple_test)
 
     runner = CliRunner()
     result = runner.invoke(
@@ -166,19 +154,9 @@ def test_diff_output_rank(builddir):
     assert "A -> A" in result.stdout
 
 
-def test_diff_with_threshold_failure(builddir):
+def test_diff_with_threshold_violation(builddir, simple_test):
     """ Positively test the diff threshold feature"""
-
-    simple_test = """
-            import abc
-            foo = 1
-            def function1():
-                pass
-            class Class1(object):
-                def method(self):
-                    pass
-            """
-    (pathlib.Path(builddir) / "src" / "test.py").write_text(dedent(simple_test))
+    (pathlib.Path(builddir) / "src" / "test.py").write_text(simple_test)
 
     runner = CliRunner()
     result = runner.invoke(

--- a/test/integration/test_diff.py
+++ b/test/integration/test_diff.py
@@ -164,3 +164,26 @@ def test_diff_output_rank(builddir):
     assert result.exit_code == 0, result.stdout
     assert "test.py" in result.stdout
     assert "A -> A" in result.stdout
+
+
+def test_diff_with_threshold_failure(builddir):
+    """ Positively test the diff threshold feature"""
+
+    simple_test = """
+            import abc
+            foo = 1
+            def function1():
+                pass
+            class Class1(object):
+                def method(self):
+                    pass
+            """
+    (pathlib.Path(builddir) / "src" / "test.py").write_text(dedent(simple_test))
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main.cli,
+        f"--debug --path {builddir} diff {_path} --thresholds halstead.h1=1".split(),
+    )
+    assert result.exit_code == 1, result.stdout
+    assert "threshold violation" in result.stdout

--- a/test/integration/test_diff.py
+++ b/test/integration/test_diff.py
@@ -174,3 +174,16 @@ def test_diff_with_threshold_violation(builddir, simple_test, value, exit_code):
     assert result.exit_code == exit_code, result.stdout
     if exit_code:
         assert "threshold violation" in result.stdout
+
+
+def test_diff_with_badly_passed_thresholds(builddir, simple_test):
+    """ Test correct handling of bad threshold formatting via CLI"""
+    (pathlib.Path(builddir) / "src" / "test.py").write_text(simple_test)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main.cli,
+        f"--debug --path {builddir} diff {_path} --thresholds halstead.h1:1".split(),
+    )
+    assert result.exit_code == 2, result.stdout
+    assert "Incorrect syntax of thresholds" in result.stdout

--- a/test/integration/test_diff.py
+++ b/test/integration/test_diff.py
@@ -187,3 +187,20 @@ def test_diff_with_badly_passed_thresholds(builddir, simple_test):
     )
     assert result.exit_code == 2, result.stdout
     assert "Incorrect syntax of thresholds" in result.stdout
+
+
+def test_diff_with_threshold_from_config(builddir, simple_test):
+    config = """
+    [wily]
+    thresholds = halstead.h1=1
+    """
+    wily_conf = pathlib.Path(builddir) / "wily.cfg"
+    wily_conf.write_text(config)
+    (pathlib.Path(builddir) / "src" / "test.py").write_text(simple_test)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main.cli, f"--debug --path {builddir} --config {wily_conf} diff {_path}".split()
+    )
+    assert result.exit_code == 1, result.stdout
+    assert "threshold violation" in result.stdout

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -58,7 +58,7 @@ def test_config_operators(tmpdir):
     assert cfg.max_revisions == wily.config.DEFAULT_MAX_REVISIONS
 
 
-def test_config_archiver(tmpdir):
+def test_config_max_revisions(tmpdir):
     """
     Test that an max-revisions can be configured
     """
@@ -75,3 +75,19 @@ def test_config_archiver(tmpdir):
     assert cfg.archiver == wily.config.DEFAULT_ARCHIVER
     assert cfg.operators == wily.config.DEFAULT_OPERATORS
     assert cfg.max_revisions == 14
+
+
+def test_config_threshold(tmpdir):
+    """
+    Test that thresholds are parsed correctly from config.
+    """
+    config = """
+    [wily]
+    thresholds = raw.loc=1,halstead.h1=2
+    """
+    config_path = os.path.join(tmpdir, "wily.cfg")
+    with open(config_path, "w") as config_f:
+        config_f.write(config)
+
+    cfg = wily.config.load(config_path)
+    assert cfg.thresholds == {"raw.loc": 1, "halstead.h1": 2}

--- a/wily/__main__.py
+++ b/wily/__main__.py
@@ -16,14 +16,12 @@ from wily.operators import resolve_operators
 
 
 class ThresholdsParamType(click.ParamType):
-    """ Custom click type for diff thresholds"""
+    """Custom click type for diff thresholds."""
 
     name = "thresholds"
 
     def convert(self, value, param, ctx):
-        """
-        Try to convert passed string to a threshold dict.
-        """
+        """Try to convert passed string to a threshold dict."""
         try:
             return get_thresholds_dict(value)
         except Exception:

--- a/wily/__main__.py
+++ b/wily/__main__.py
@@ -16,9 +16,14 @@ from wily.operators import resolve_operators
 
 
 class ThresholdsParamType(click.ParamType):
+    """ Custom click type for diff thresholds"""
+
     name = "thresholds"
 
     def convert(self, value, param, ctx):
+        """
+        Try to convert passed string to a threshold dict.
+        """
         try:
             return get_thresholds_dict(value)
         except Exception:

--- a/wily/__main__.py
+++ b/wily/__main__.py
@@ -359,12 +359,7 @@ def handle_no_cache(context):
         revisions = int(revisions)
         path = input("Path to your source files; comma-separated for multiple: ")
         paths = path.split(",")
-        context.invoke(
-            build,
-            max_revisions=revisions,
-            targets=paths,
-            operators=None,
-        )
+        context.invoke(build, max_revisions=revisions, targets=paths, operators=None)
 
 
 if __name__ == "__main__":

--- a/wily/__main__.py
+++ b/wily/__main__.py
@@ -1,9 +1,9 @@
 # -*- coding: UTF-8 -*-
 """Main command line."""
 
-import click
-
 from pathlib import Path
+
+import click
 
 from wily import logger, __version__
 from wily.archivers import resolve_archiver
@@ -13,6 +13,19 @@ from wily.config import load as load_config
 from wily.decorators import add_version
 from wily.helper.custom_enums import ReportFormat
 from wily.operators import resolve_operators
+
+
+class ThresholdsParamType(click.ParamType):
+    name = "thresholds"
+
+    def convert(self, value, param, ctx):
+        try:
+            return get_thresholds_dict(value)
+        except Exception:
+            self.fail(
+                "Incorrect syntax of thresholds. Please use the following syntax: "
+                "`--thresholds halstead.h1=1,raw.loc=2`"
+            )
 
 
 @click.group()
@@ -225,8 +238,9 @@ def report(ctx, file, metrics, number, message, format, console_format, output):
 )
 @click.option(
     "--thresholds",
+    type=ThresholdsParamType(),
     default=None,
-    help="comma-seperated list of threshold and value, separated by equal sign. See list-metrics for choices",
+    help="comma-separated list of threshold and value, separated by equal sign. See list-metrics for choices",
 )
 @click.pass_context
 def diff(ctx, files, metrics, all, detail, thresholds):
@@ -243,8 +257,6 @@ def diff(ctx, files, metrics, all, detail, thresholds):
         metrics = metrics.split(",")
         logger.info(f"Using specified metrics {metrics}")
 
-    if thresholds:
-        thresholds = get_thresholds_dict(thresholds)
     from wily.commands.diff import diff
 
     logger.debug(f"Running diff on {files} for metric {metrics}")

--- a/wily/__main__.py
+++ b/wily/__main__.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from wily import logger, __version__
 from wily.archivers import resolve_archiver
-from wily.cache import exists, get_default_metrics
+from wily.cache import exists, get_default_metrics, get_thresholds_dict
 from wily.config import DEFAULT_CONFIG_PATH, DEFAULT_GRID_STYLE
 from wily.config import load as load_config
 from wily.decorators import add_version
@@ -166,7 +166,7 @@ def index(ctx, message):
 @click.option(
     "--console-format",
     default=DEFAULT_GRID_STYLE,
-    help="Style for the console grid, see Tabulate Documentation for a list of styles."
+    help="Style for the console grid, see Tabulate Documentation for a list of styles.",
 )
 @click.option(
     "-o", "--output", help="Output report to specified HTML path, e.g. reports/out.html"
@@ -223,8 +223,13 @@ def report(ctx, file, metrics, number, message, format, console_format, output):
     default=True,
     help="Show function/class level metrics where available",
 )
+@click.option(
+    "--thresholds",
+    default=None,
+    help="comma-seperated list of threshold and value, separated by equal sign. See list-metrics for choices",
+)
 @click.pass_context
-def diff(ctx, files, metrics, all, detail):
+def diff(ctx, files, metrics, all, detail, thresholds):
     """Show the differences in metrics for each file."""
     config = ctx.obj["CONFIG"]
 
@@ -238,11 +243,18 @@ def diff(ctx, files, metrics, all, detail):
         metrics = metrics.split(",")
         logger.info(f"Using specified metrics {metrics}")
 
+    if thresholds:
+        thresholds = get_thresholds_dict(thresholds)
     from wily.commands.diff import diff
 
     logger.debug(f"Running diff on {files} for metric {metrics}")
     diff(
-        config=config, files=files, metrics=metrics, changes_only=not all, detail=detail
+        config=config,
+        files=files,
+        metrics=metrics,
+        changes_only=not all,
+        detail=detail,
+        thresholds=thresholds,
     )
 
 

--- a/wily/cache.py
+++ b/wily/cache.py
@@ -273,3 +273,20 @@ def get(config, archiver, revision):
     with (root / f"{revision}.json").open("r") as rev_f:
         index = json.load(rev_f)
     return index
+
+
+def get_thresholds_dict(threshold):
+    """
+    Returns a dict of threshold from a threshold string
+
+    :param threshold: A string representing desired thresholds
+    :type threshold: ``str``
+
+    :return: A dictionary of thresholds
+    :rtype: ``dict``
+    """
+    d = {}
+    for v in threshold.split(","):
+        key, value = v.split("=")
+        d[key] = int(value) if value.isdigit() else value
+    return d

--- a/wily/cache.py
+++ b/wily/cache.py
@@ -286,6 +286,9 @@ def get_thresholds_dict(threshold):
     :rtype: ``dict``
     """
     d = {}
+    if not threshold:
+        return d
+
     for v in threshold.split(","):
         key, value = v.split("=")
         d[key] = int(value) if value.isdigit() else value

--- a/wily/cache.py
+++ b/wily/cache.py
@@ -277,7 +277,7 @@ def get(config, archiver, revision):
 
 def get_thresholds_dict(threshold):
     """
-    Returns a dict of threshold from a threshold string
+    Return a dict of threshold from a threshold string.
 
     :param threshold: A string representing desired thresholds
     :type threshold: ``str``

--- a/wily/commands/diff.py
+++ b/wily/commands/diff.py
@@ -51,7 +51,7 @@ def diff(config, files, metrics, changes_only=True, detail=True, thresholds=None
     metrics = [(metric.split(".")[0], resolve_metric(metric)) for metric in metrics]
     data = {}
     results = []
-    diffs = {}
+    deltas = {}
     # Build a set of operators
     _operators = [operator.cls(config) for operator in operators]
 
@@ -99,7 +99,7 @@ def diff(config, files, metrics, changes_only=True, detail=True, thresholds=None
             if new != current:
                 has_changes = True
             if metric.type in (int, float) and new != "-" and current != "-":
-                diffs.setdefault(
+                deltas.setdefault(
                     file, {f"{operator}.{metric.name}": (current - new, metric.measure)}
                 )
                 # TODO save diff even when both metrics are non numeric
@@ -138,10 +138,10 @@ def diff(config, files, metrics, changes_only=True, detail=True, thresholds=None
         )
     errors = []
     if thresholds:
-        for file, diff_ in diffs.items():
+        for file, delta in deltas.items():
             for threshold in thresholds:
-                if threshold in diff_:
-                    value, metric_type = diff_[threshold]
+                if threshold in delta:
+                    value, metric_type = delta[threshold]
                     threshold_ = thresholds[threshold]
                     op_ = op.gt if metric_type is MetricType.AimLow else op.lt
                     if op_(value, threshold_):

--- a/wily/commands/diff.py
+++ b/wily/commands/diff.py
@@ -4,6 +4,7 @@ Diff command.
 Compares metrics between uncommitted files and indexed files.
 """
 import os
+from collections import defaultdict
 
 import tabulate
 
@@ -49,7 +50,7 @@ def diff(config, files, metrics, changes_only=True, detail=True):
     metrics = [(metric.split(".")[0], resolve_metric(metric)) for metric in metrics]
     data = {}
     results = []
-
+    diffs = defaultdict(dict)
     # Build a set of operators
     _operators = [operator.cls(config) for operator in operators]
 
@@ -97,6 +98,7 @@ def diff(config, files, metrics, changes_only=True, detail=True):
             if new != current:
                 has_changes = True
             if metric.type in (int, float) and new != "-" and current != "-":
+                diffs[file].update({'{}.{}'.format(operator, metric.name): current - new})
                 if current > new:
                     metrics_data.append(
                         "{0:n} -> \u001b[{2}m{1:n}\u001b[0m".format(

--- a/wily/commands/diff.py
+++ b/wily/commands/diff.py
@@ -136,19 +136,23 @@ def diff(config, files, metrics, changes_only=True, detail=True, thresholds=None
                 headers=headers, tabular_data=results, tablefmt=DEFAULT_GRID_STYLE
             )
         )
+    if not thresholds:
+        exit()
+
     errors = []
-    if thresholds:
-        for file, delta in deltas.items():
-            for threshold in thresholds:
-                if threshold in delta:
-                    value, metric_type = delta[threshold]
-                    threshold_ = thresholds[threshold]
-                    op_ = op.gt if metric_type is MetricType.AimLow else op.lt
-                    if op_(value, threshold_):
-                        errors.append(
-                            f"File {file} has a threshold violation: allowed value is {threshold_}"
-                            f"and actual value is {value}"
-                        )
+    for file, delta in deltas.items():
+        for threshold in thresholds:
+            if threshold not in delta:
+                continue
+            value, metric_type = delta[threshold]
+            threshold_ = thresholds[threshold]
+            op_ = op.gt if metric_type is MetricType.AimLow else op.lt
+            if not op_(value, threshold_):
+                continue
+            errors.append(
+                f"File {file} has a threshold violation: allowed value is {threshold_}"
+                f"and actual value is {value}"
+            )
     if errors:
         print("\n".join(errors))
         exit(1)

--- a/wily/commands/diff.py
+++ b/wily/commands/diff.py
@@ -21,7 +21,7 @@ from wily.operators import (
 from wily.state import State
 
 
-def diff(config, files, metrics, changes_only=True, detail=True):
+def diff(config, files, metrics, changes_only=True, detail=True, thresholds=None):
     """
     Show the differences in metrics for each of the files.
 
@@ -132,3 +132,16 @@ def diff(config, files, metrics, changes_only=True, detail=True):
                 headers=headers, tabular_data=results, tablefmt=DEFAULT_GRID_STYLE
             )
         )
+    errors = []
+    if thresholds:
+        for file, diff_ in diffs.items():
+            for threshold in thresholds:
+                if (
+                    threshold in diff_ and diff_[threshold] > thresholds[threshold]
+                ):  # TODO consider metric.measure for this and do not assume that higher is worse
+                    errors.append(
+                        f"File {file} has a threshold violation: allowed value is {thresholds[threshold]} and actual value is {diff_[threshold]}"
+                    )
+    if errors:
+        print("\n".join(errors))
+        exit(1)

--- a/wily/commands/diff.py
+++ b/wily/commands/diff.py
@@ -171,5 +171,4 @@ def diff(config, files, metrics, changes_only=True, detail=True, thresholds=None
                 headers=headers, tabular_data=results, tablefmt=DEFAULT_GRID_STYLE
             )
         )
-
-    handle_thresholds(deltas, thresholds)
+    handle_thresholds(deltas, thresholds or config.thresholds)

--- a/wily/commands/diff.py
+++ b/wily/commands/diff.py
@@ -98,7 +98,9 @@ def diff(config, files, metrics, changes_only=True, detail=True, thresholds=None
             if new != current:
                 has_changes = True
             if metric.type in (int, float) and new != "-" and current != "-":
-                diffs[file].update({'{}.{}'.format(operator, metric.name): current - new})
+                diffs[file].update(
+                    {f"{operator}.{metric.name}": current - new}
+                )  # TODO save diff even when both metrics are non numeric
                 if current > new:
                     metrics_data.append(
                         "{0:n} -> \u001b[{2}m{1:n}\u001b[0m".format(
@@ -140,7 +142,8 @@ def diff(config, files, metrics, changes_only=True, detail=True, thresholds=None
                     threshold in diff_ and diff_[threshold] > thresholds[threshold]
                 ):  # TODO consider metric.measure for this and do not assume that higher is worse
                     errors.append(
-                        f"File {file} has a threshold violation: allowed value is {thresholds[threshold]} and actual value is {diff_[threshold]}"
+                        f"File {file} has a threshold violation: allowed value is {thresholds[threshold]}"
+                        f"and actual value is {diff_[threshold]}"
                     )
     if errors:
         print("\n".join(errors))

--- a/wily/commands/diff.py
+++ b/wily/commands/diff.py
@@ -5,7 +5,6 @@ Compares metrics between uncommitted files and indexed files.
 """
 import operator as op
 import os
-from collections import defaultdict
 
 import tabulate
 
@@ -52,7 +51,7 @@ def diff(config, files, metrics, changes_only=True, detail=True, thresholds=None
     metrics = [(metric.split(".")[0], resolve_metric(metric)) for metric in metrics]
     data = {}
     results = []
-    diffs = defaultdict(dict)
+    diffs = {}
     # Build a set of operators
     _operators = [operator.cls(config) for operator in operators]
 
@@ -100,9 +99,10 @@ def diff(config, files, metrics, changes_only=True, detail=True, thresholds=None
             if new != current:
                 has_changes = True
             if metric.type in (int, float) and new != "-" and current != "-":
-                diffs[file].update(
-                    {f"{operator}.{metric.name}": (current - new, metric.measure)}
-                )  # TODO save diff even when both metrics are non numeric
+                diffs.setdefault(
+                    file, {f"{operator}.{metric.name}": (current - new, metric.measure)}
+                )
+                # TODO save diff even when both metrics are non numeric
                 if current > new:
                     metrics_data.append(
                         "{0:n} -> \u001b[{2}m{1:n}\u001b[0m".format(

--- a/wily/config.py
+++ b/wily/config.py
@@ -140,7 +140,7 @@ def load(config_path=DEFAULT_CONFIG_PATH):
         )
     )
     thresholds = config.get(
-        section=DEFAULT_CONFIG_SECTION, option="thresholds", fallback={}
+        section=DEFAULT_CONFIG_SECTION, option="thresholds", fallback=""
     )
     thresholds = get_thresholds_dict(thresholds)
 

--- a/wily/config.py
+++ b/wily/config.py
@@ -15,6 +15,7 @@ from typing import Any, List
 
 import wily.operators as operators
 from wily.archivers import ARCHIVER_GIT
+from wily.cache import get_thresholds_dict
 
 logger = logging.getLogger(__name__)
 
@@ -51,6 +52,7 @@ class WilyConfig(object):
     path: str
     max_revisions: int
     targets: List[str] = None
+    thresholds: dict = field(default_factory=dict)
     checkout_options: dict = field(default_factory=dict)
 
     def __post_init__(self):
@@ -137,7 +139,15 @@ def load(config_path=DEFAULT_CONFIG_PATH):
             fallback=DEFAULT_MAX_REVISIONS,
         )
     )
+    thresholds = config.get(
+        section=DEFAULT_CONFIG_SECTION, option="thresholds", fallback={}
+    )
+    thresholds = get_thresholds_dict(thresholds)
 
     return WilyConfig(
-        operators=operators, archiver=archiver, path=path, max_revisions=max_revisions
+        operators=operators,
+        archiver=archiver,
+        path=path,
+        max_revisions=max_revisions,
+        thresholds=thresholds,
     )


### PR DESCRIPTION
Setting exit status via predefined threshold will allow using wily via CI. Relating to issue #66.

# Changes 

* Added ability to pass thresholds to diff command per operator

# Usage:

```bash
$ wily diff [FILES] --thresholds halstead.h1=1,raw.loc=50
```

## TODO

- [x] Check for metric type when determining if threshold was passed or not
- [ ] Handle diffs for scenarios where files/modules were renamed, resulting in `-` as the base value
- [x] Add ability to pass threshold via config file
- [ ] Add more tests
- [ ] Have a nicer output for errors
- [ ] Add logging
