### PR TITLE
Bugfix: handle objects that have the same name as the metrics

### DIFF
--- a/test/integration/test_all_operators.py
+++ b/test/integration/test_all_operators.py
@@ -9,10 +9,11 @@ from click.testing import CliRunner
 import pathlib
 from textwrap import dedent
 
+from git import Repo, Actor
+
 import wily.__main__ as main
 
 _path = "src\\test.py" if sys.platform == "win32" else "src/test.py"
-
 
 operators = (
     "halstead",
@@ -66,3 +67,55 @@ def test_operator(operator, gitdir):
     )
     assert result.exit_code == 0, result.stdout
     assert "test.py" in result.stdout
+
+
+@pytest.mark.parametrize("operator", operators)
+def test_operator_on_code_with_metric_named_objects(operator, tmpdir, cache_path):
+    code_with_metric_named_objects = """
+
+    # CyclomaticComplexity
+    def complexity(): pass
+
+    # Halstead
+    def h1(): pass
+    def h2(): pass
+    def N1(): pass
+    def N2(): pass
+    def vocabulary(): pass
+    def length(): pass
+    def volume(): pass
+    def difficulty(): pass
+    def error(): pass
+
+    # Maintainability
+    def rank(): pass
+    def mi(): pass
+
+    # RawMetrics
+    def loc(): pass
+    def lloc(): pass
+    def sloc(): pass
+    def comments(): pass
+    def multi(): pass
+    def blank(): pass
+    def single_comments(): pass
+
+    """
+
+    testpath = pathlib.Path(tmpdir) / "test.py"
+    author = Actor("An author", "author@example.com")
+    committer = Actor("A committer", "committer@example.com")
+
+    with open(testpath, "w") as test_py:
+        test_py.write(dedent(code_with_metric_named_objects))
+
+    with Repo.init(path=tmpdir) as repo:
+        repo.index.add(["test.py"])
+        repo.index.commit("add test.py", author=author, committer=committer)
+
+    runner = CliRunner()
+
+    result = runner.invoke(
+        main.cli, ["--debug", "--path", tmpdir, "--cache", cache_path, "build", str(testpath), "-o", operator]
+    )
+    assert result.exit_code == 0, result.stdout

--- a/test/unit/test_cyclomatic.py
+++ b/test/unit/test_cyclomatic.py
@@ -15,7 +15,8 @@ def test_cyclomatic_bad_entry_data(harvester):
     MockCC.results = {"test.py": [{"complexity": 5}]}
     op = wily.operators.cyclomatic.CyclomaticComplexityOperator(DEFAULT_CONFIG)
     results = op.run("test.py", {})
-    assert results == {"test.py": {"complexity": 0}}
+    assert results == {"test.py": {"detailed": {},
+                                   "total": {"complexity": 0}}}
 
 
 @mock.patch("wily.operators.cyclomatic.harvesters.CCHarvester", return_value=MockCC)
@@ -23,7 +24,8 @@ def test_cyclomatic_error_case(harvester):
     MockCC.results = {"test.py": {"error": "bad data"}}
     op = wily.operators.cyclomatic.CyclomaticComplexityOperator(DEFAULT_CONFIG)
     results = op.run("test.py", {})
-    assert results == {"test.py": {"complexity": 0}}
+    assert results == {"test.py": {"detailed": {},
+                                   "total": {"complexity": 0}}}
 
 
 @mock.patch("wily.operators.cyclomatic.harvesters.CCHarvester", return_value=MockCC)
@@ -31,4 +33,5 @@ def test_cyclomatic_error_case_unexpected(harvester):
     MockCC.results = {"test.py": [1234]}
     op = wily.operators.cyclomatic.CyclomaticComplexityOperator(DEFAULT_CONFIG)
     results = op.run("test.py", {})
-    assert results == {"test.py": {"complexity": 0}}
+    assert results == {"test.py": {"detailed": {},
+                                   "total": {"complexity": 0}}}

--- a/wily/commands/build.py
+++ b/wily/commands/build.py
@@ -102,18 +102,18 @@ def build(config, archiver, operators):
                             for path in result.keys()
                             if root in pathlib.Path(path).parents
                         ]
-                        result[str(root)] = {}
+                        result[str(root)] = {"total": {}}
                         # aggregate values
                         for metric in resolve_operator(operator_name).cls.metrics:
                             func = metric.aggregate
                             values = [
-                                result[aggregate][metric.name]
+                                result[aggregate]["total"][metric.name]
                                 for aggregate in aggregates
                                 if aggregate in result
-                                and metric.name in result[aggregate]
+                                and metric.name in result[aggregate]["total"]
                             ]
                             if len(values) > 0:
-                                result[str(root)][metric.name] = func(values)
+                                result[str(root)]["total"][metric.name] = func(values)
 
                     stats["operator_data"][operator_name] = result
                     bar.next()

--- a/wily/commands/diff.py
+++ b/wily/commands/diff.py
@@ -69,9 +69,9 @@ def diff(config, files, metrics, changes_only=True, detail=True):
                     extra.extend(
                         [
                             f"{file}:{k}"
-                            for k in data[operator][file].keys()
+                            for k in data[operator][file]["detailed"].keys()
                             if k != metric.name
-                            and isinstance(data[operator][file][k], dict)
+                            and isinstance(data[operator][file]["detailed"][k], dict)
                         ]
                     )
                 except KeyError:

--- a/wily/operators/__init__.py
+++ b/wily/operators/__init__.py
@@ -190,8 +190,8 @@ def get_metric(revision, operator, path, key):
     """
     Get a metric from the cache.
 
-    :param revision: The revision id.
-    :type  revision: ``str``
+    :param revision: The revision data.
+    :type  revision: ``dict``
 
     :param operator: The operator name.
     :type  operator: ``str``
@@ -207,7 +207,7 @@ def get_metric(revision, operator, path, key):
     """
     if ":" in path:
         part, entry = path.split(":")
-        val = revision[operator][part][entry][key]
+        val = revision[operator][part]["detailed"][entry][key]
     else:
-        val = revision[operator][path][key]
+        val = revision[operator][path]["total"][key]
     return val

--- a/wily/operators/cyclomatic.py
+++ b/wily/operators/cyclomatic.py
@@ -70,7 +70,8 @@ class CyclomaticComplexityOperator(BaseOperator):
         logger.debug("Running CC harvester")
         results = {}
         for filename, details in dict(self.harvester.results).items():
-            results[filename] = {}
+            results[filename] = {"detailed": {},
+                                 "total": {}}
             total = 0  # running CC total
             for instance in details:
                 if isinstance(instance, Class):
@@ -88,10 +89,10 @@ class CyclomaticComplexityOperator(BaseOperator):
                             f"Unexpected result from Radon : {instance} of {type(instance)}. Please report on Github."
                         )
                         continue
-                results[filename][i["fullname"]] = i
+                results[filename]["detailed"][i["fullname"]] = i
                 del i["fullname"]
                 total += i["complexity"]
-            results[filename]["complexity"] = total
+            results[filename]["total"]["complexity"] = total
         return results
 
     @staticmethod

--- a/wily/operators/halstead.py
+++ b/wily/operators/halstead.py
@@ -71,19 +71,20 @@ class HalsteadOperator(BaseOperator):
         logger.debug("Running halstead harvester")
         results = {}
         for filename, details in dict(self.harvester.results).items():
-            results[filename] = {}
+            results[filename] = {"detailed": {},
+                                 "total": {}}
             for instance in details:
                 if isinstance(instance, list):
                     for item in instance:
                         function, report = item
-                        results[filename][function] = self._report_to_dict(report)
+                        results[filename]["detailed"][function] = self._report_to_dict(report)
                 else:
                     if isinstance(instance, str) and instance == "error":
                         logger.warning(
                             f"Failed to run Halstead harvester on {filename} : {details['error']}"
                         )
                         continue
-                    results[filename] = self._report_to_dict(instance)
+                    results[filename]["total"] = self._report_to_dict(instance)
         return results
 
     def _report_to_dict(self, report):

--- a/wily/operators/maintainability.py
+++ b/wily/operators/maintainability.py
@@ -75,4 +75,7 @@ class MaintainabilityIndexOperator(BaseOperator):
         :rtype: ``dict``
         """
         logger.debug("Running maintainability harvester")
-        return dict(self.harvester.results)
+        results = {}
+        for filename, metrics in dict(self.harvester.results).items():
+            results[filename] = {"total": metrics}
+        return results

--- a/wily/operators/raw.py
+++ b/wily/operators/raw.py
@@ -59,4 +59,7 @@ class RawMetricsOperator(BaseOperator):
         :rtype: ``dict``
         """
         logger.debug("Running raw harvester")
-        return dict(self.harvester.results)
+        results = {}
+        for filename, metrics in dict(self.harvester.results).items():
+            results[filename] = {"total": metrics}
+        return results


### PR DESCRIPTION
This is a PR to fix issue #73.

The PR introduces an extra level in the results dict for detailed and total metrics. This is to avoid mangling file metric aggregates and object metrics when the analyzed file happens to include objects that have the same name as the metrics (e.g. a function called `h1`).