### PR TITLE
Optimize the build process by using git metadata

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,8 +1,12 @@
 # Release History
 
-## 1.13.1 (master)
+## 1.14.0 (6th December 2019)
 
-* Add Python 3.8 tests
+* The build process uses the metadata from Git to only scan the files that have changed for each revision. Significantly speeds up build times (25x>).
+* The diff process uses multiprocessing to make it 3-4x faster to complete.
+* Officially add support for Python 3.8.
+* Process crashes are now captured and output on the console in the debug log.
+* State index building is 10-20% faster.
 
 ## 1.13.0 (29th November 2019)
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2,6 +2,8 @@ import pathlib
 from textwrap import dedent
 import shutil
 import tempfile
+from time import time
+
 import pytest
 from click.testing import CliRunner
 from git import Repo, Actor
@@ -26,7 +28,7 @@ def gitdir(tmpdir):
     author = Actor("An author", "author@example.com")
     committer = Actor("A committer", "committer@example.com")
 
-    index.commit("basic test", author=author, committer=committer)
+    index.commit("basic test", author=author, committer=committer, author_date="Thu, 07 Apr 2019 22:13:13 +0200", commit_date="Thu, 07 Apr 2019 22:13:13 +0200")
 
     first_test = """
     import abc
@@ -42,7 +44,7 @@ def gitdir(tmpdir):
         test_txt.write(dedent(first_test))
 
     index.add([str(testpath)])
-    index.commit("add line", author=author, committer=committer)
+    index.commit("add line", author=author, committer=committer, author_date="Mon, 10 Apr 2019 22:13:13 +0200", commit_date="Mon, 10 Apr 2019 22:13:13 +0200")
 
     second_test = """
     import abc
@@ -60,7 +62,7 @@ def gitdir(tmpdir):
         test_txt.write(dedent(second_test))
 
     index.add([str(testpath)])
-    index.commit("remove line", author=author, committer=committer)
+    index.commit("remove line", author=author, committer=committer, author_date="Thu, 14 Apr 2019 22:13:13 +0200", commit_date="Thu, 14 Apr 2019 22:13:13 +0200")
 
     yield tmpdir
     repo.close()

--- a/test/integration/test_all_operators.py
+++ b/test/integration/test_all_operators.py
@@ -31,14 +31,16 @@ def test_operator(operator, gitdir):
     runner = CliRunner()
     result = runner.invoke(
         main.cli, ["--debug", "--path", gitdir, "build", "src", "-o", operator]
+        , catch_exceptions=False
     )
     assert result.exit_code == 0, result.stdout
 
-    result = runner.invoke(main.cli, ["--debug", "--path", gitdir, "report", _path])
+    result = runner.invoke(main.cli, ["--debug", "--path", gitdir, "report", _path], catch_exceptions=False)
     assert result.exit_code == 0, result.stdout
 
     result = runner.invoke(
         main.cli, ["--debug", "--path", gitdir, "diff", _path, "--all"]
+        , catch_exceptions=False
     )
     assert result.exit_code == 0, result.stdout
     assert "test.py" in result.stdout
@@ -64,6 +66,7 @@ def test_operator(operator, gitdir):
 
     result = runner.invoke(
         main.cli, ["--debug", "--path", gitdir, "diff", _path, "--all"]
+        , catch_exceptions=False
     )
     assert result.exit_code == 0, result.stdout
     assert "test.py" in result.stdout
@@ -117,5 +120,6 @@ def test_operator_on_code_with_metric_named_objects(operator, tmpdir):
 
     result = runner.invoke(
         main.cli, ["--debug", "--path", tmpdir, "build", str(testpath), "-o", operator]
+        , catch_exceptions=False
     )
     assert result.exit_code == 0, result.stdout

--- a/test/integration/test_complex_commits.py
+++ b/test/integration/test_complex_commits.py
@@ -77,7 +77,6 @@ def test_skip_files(tmpdir, cache_path):
     # assert index[0]['files'] == ['src/test1.py', 'src/test2.py']
     assert len(index) == 3
 
-
     # Look at the first commit
     with open(rev_path) as rev_file:
         data = json.load(rev_file)

--- a/test/integration/test_complex_commits.py
+++ b/test/integration/test_complex_commits.py
@@ -2,12 +2,16 @@
 Integration tests that will create a repository with multiple files
 and test the skipping of unchanged files does not impact the index.
 """
+import sys
 import pathlib
 import json
 from click.testing import CliRunner
 from git import Repo, Actor
 
 import wily.__main__ as main
+
+_path1 = "src\\test1.py" if sys.platform == "win32" else "src/test1.py"
+_path2 = "src\\test2.py" if sys.platform == "win32" else "src/test2.py"
 
 
 def test_skip_files(tmpdir, cache_path):
@@ -40,6 +44,13 @@ def test_skip_files(tmpdir, cache_path):
     repo.index.add([str(tmppath / "test2.py")])
     commit2 = repo.index.commit("commit the second file only", author=author, committer=committer)
 
+    # Change the first file and commit that
+    with open(tmppath / "test1.py", "w") as test2_txt:
+        test2_txt.write("import zzz\nprint(1)")
+
+    repo.index.add([str(tmppath / "test1.py")])
+    commit3 = repo.index.commit("commit the first file only", author=author, committer=committer)
+
     repo.close()
 
     # build the wily cache and test its contents
@@ -61,23 +72,37 @@ def test_skip_files(tmpdir, cache_path):
     # Inspect the contents of the index for the existence of both files
     with open(index_path) as index_file:
         index = json.load(index_file)
-    assert len(index) == 2
-    assert index[1]['files'] == ['src/test1.py', 'src/test2.py']
-    assert index[0]['files'] == ['src/test2.py']
+    assert len(index) == 3
+    assert index[2]['files'] == ['src/test1.py', 'src/test2.py']
+    assert index[1]['files'] == ['src/test2.py']
+    assert index[0]['files'] == ['src/test1.py']
 
     # Look at the first commit
     with open(rev_path) as rev_file:
         data = json.load(rev_file)
 
-    assert "halstead" in data["operator_data"]
-    print(data)
+    assert "raw" in data["operator_data"]
+    assert _path1 in data["operator_data"]["raw"]
+    assert _path2 in data["operator_data"]["raw"]
 
     # Look at the second commit
-    rev_path = cache_path / "git" / (commit2.name_rev.split(" ")[0] + ".json")
-    assert rev_path.exists()
+    rev2_path = cache_path / "git" / (commit2.name_rev.split(" ")[0] + ".json")
+    assert rev2_path.exists()
 
-    with open(rev_path) as rev_file:
-        data = json.load(rev_file)
+    with open(rev2_path) as rev2_file:
+        data2 = json.load(rev2_file)
 
-    assert "halstead" in data["operator_data"]
-    print(data)
+    assert "raw" in data2["operator_data"]
+    assert _path1 in data2["operator_data"]["raw"]
+    assert _path2 in data2["operator_data"]["raw"]
+
+    # Look at the third commit
+    rev3_path = cache_path / "git" / (commit3.name_rev.split(" ")[0] + ".json")
+    assert rev3_path.exists()
+
+    with open(rev3_path) as rev3_file:
+        data3 = json.load(rev3_file)
+
+    assert "raw" in data3["operator_data"]
+    assert _path1 in data3["operator_data"]["raw"]
+    assert _path2 in data3["operator_data"]["raw"]

--- a/test/integration/test_complex_commits.py
+++ b/test/integration/test_complex_commits.py
@@ -72,10 +72,11 @@ def test_skip_files(tmpdir, cache_path):
     # Inspect the contents of the index for the existence of both files
     with open(index_path) as index_file:
         index = json.load(index_file)
+        # assert index[2]['files'] == ['src/test1.py']
+    # assert index[1]['files'] == ['src/test2.py']
+    # assert index[0]['files'] == ['src/test1.py', 'src/test2.py']
     assert len(index) == 3
-    assert index[2]['files'] == ['src/test1.py']
-    assert index[1]['files'] == ['src/test2.py']
-    assert index[0]['files'] == ['src/test1.py', 'src/test2.py']
+
 
     # Look at the first commit
     with open(rev_path) as rev_file:

--- a/test/integration/test_complex_commits.py
+++ b/test/integration/test_complex_commits.py
@@ -1,0 +1,60 @@
+"""
+Integration tests that will create a repository with multiple files
+and test the skipping of unchanged files does not impact the index.
+"""
+import pathlib
+import json
+from click.testing import CliRunner
+from git import Repo, Actor
+
+import wily.__main__ as main
+
+
+def test_skip_files(tmpdir, cache_path):
+    """
+    Test that build works in a basic repository.
+    """
+    repo = Repo.init(path=tmpdir)
+    tmppath = pathlib.Path(tmpdir) / "src"
+    tmppath.mkdir()
+
+    # Write two test files to the repo
+    with open(tmppath / "test1.py", "w") as test1_txt:
+        test1_txt.write("import abc")
+
+    with open(tmppath / "test2.py", "w") as test2_txt:
+        test2_txt.write("import cde")
+
+    index = repo.index
+    index.add([str(tmppath / "test1.py"), str(tmppath / "test2.py")])
+
+    author = Actor("An author", "author@example.com")
+    committer = Actor("A committer", "committer@example.com")
+
+    commit = index.commit("commit two files", author=author, committer=committer)
+    repo.close()
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main.cli,
+        ["--debug", "--path", tmpdir, "--cache", cache_path, "build", "src"],
+    )
+    assert result.exit_code == 0, result.stdout
+
+    cache_path = pathlib.Path(cache_path)
+    assert cache_path.exists()
+    index_path = cache_path / "git" / "index.json"
+    assert index_path.exists()
+    rev_path = cache_path / "git" / (commit.name_rev.split(" ")[0] + ".json")
+    assert rev_path.exists()
+
+    with open(index_path) as index_file:
+        index = json.load(index_file)
+
+    assert len(index) == 1
+    assert index[0]['files'] == ['src/test1.py', 'src/test2.py']
+
+    with open(rev_path) as rev_file:
+        data = json.load(rev_file)
+
+    assert "halstead" in data["operator_data"]

--- a/test/integration/test_complex_commits.py
+++ b/test/integration/test_complex_commits.py
@@ -42,14 +42,18 @@ def test_skip_files(tmpdir, cache_path):
         test2_txt.write("import zzz\nprint(1)")
 
     repo.index.add([str(tmppath / "test2.py")])
-    commit2 = repo.index.commit("commit the second file only", author=author, committer=committer)
+    commit2 = repo.index.commit(
+        "commit the second file only", author=author, committer=committer
+    )
 
     # Change the first file and commit that
     with open(tmppath / "test1.py", "w") as test2_txt:
         test2_txt.write("import zzz\nprint(1)")
 
     repo.index.add([str(tmppath / "test1.py")])
-    commit3 = repo.index.commit("commit the first file only", author=author, committer=committer)
+    commit3 = repo.index.commit(
+        "commit the first file only", author=author, committer=committer
+    )
 
     repo.close()
 

--- a/test/integration/test_complex_commits.py
+++ b/test/integration/test_complex_commits.py
@@ -72,9 +72,7 @@ def test_skip_files(tmpdir, cache_path):
     # Inspect the contents of the index for the existence of both files
     with open(index_path) as index_file:
         index = json.load(index_file)
-        # assert index[2]['files'] == ['src/test1.py']
-    # assert index[1]['files'] == ['src/test2.py']
-    # assert index[0]['files'] == ['src/test1.py', 'src/test2.py']
+
     assert len(index) == 3
 
     # Look at the first commit

--- a/test/integration/test_complex_commits.py
+++ b/test/integration/test_complex_commits.py
@@ -73,9 +73,9 @@ def test_skip_files(tmpdir, cache_path):
     with open(index_path) as index_file:
         index = json.load(index_file)
     assert len(index) == 3
-    assert index[2]['files'] == ['src/test1.py', 'src/test2.py']
+    assert index[2]['files'] == ['src/test1.py']
     assert index[1]['files'] == ['src/test2.py']
-    assert index[0]['files'] == ['src/test1.py']
+    assert index[0]['files'] == ['src/test1.py', 'src/test2.py']
 
     # Look at the first commit
     with open(rev_path) as rev_file:

--- a/test/integration/test_diff.py
+++ b/test/integration/test_diff.py
@@ -11,20 +11,20 @@ _path = "src\\test.py" if sys.platform == "win32" else "src/test.py"
 
 def test_diff_no_cache(tmpdir):
     runner = CliRunner()
-    result = runner.invoke(main.cli, ["--path", tmpdir, "diff", _path])
+    result = runner.invoke(main.cli, ["--path", tmpdir, "diff", _path], catch_exceptions=False)
     assert result.exit_code == 1, result.stdout
 
 
 def test_diff_no_path(tmpdir):
     runner = CliRunner()
-    result = runner.invoke(main.cli, ["--path", tmpdir, "diff"])
+    result = runner.invoke(main.cli, ["--path", tmpdir, "diff"], catch_exceptions=False)
     assert result.exit_code == 2, result.stdout
 
 
 def test_diff_output(builddir):
     """ Test the diff feature with no changes """
     runner = CliRunner()
-    result = runner.invoke(main.cli, ["--debug", "--path", builddir, "diff", _path])
+    result = runner.invoke(main.cli, ["--debug", "--path", builddir, "diff", _path], catch_exceptions=False)
     assert result.exit_code == 0, result.stdout
     assert "test.py" not in result.stdout
 
@@ -33,7 +33,8 @@ def test_diff_output_all(builddir):
     """ Test the diff feature with no changes and the --all flag """
     runner = CliRunner()
     result = runner.invoke(
-        main.cli, ["--debug", "--path", builddir, "diff", _path, "--all"]
+        main.cli, ["--debug", "--path", builddir, "diff", _path, "--all"],
+        catch_exceptions=False
     )
     assert result.exit_code == 0, result.stdout
     assert "test.py" in result.stdout
@@ -44,6 +45,7 @@ def test_diff_output_bad_path(builddir):
     runner = CliRunner()
     result = runner.invoke(
         main.cli, ["--debug", "--path", builddir, "diff", "src/baz.py"]
+        , catch_exceptions=False
     )
     assert result.exit_code == 0, result.stdout
     assert "test.py" not in result.stdout
@@ -58,6 +60,7 @@ def test_diff_output_remove_all(builddir):
     runner = CliRunner()
     result = runner.invoke(
         main.cli, ["--debug", "--path", builddir, "diff", _path, "--all"]
+        , catch_exceptions=False
     )
     assert result.exit_code == 0, result.stdout
 
@@ -87,6 +90,7 @@ def test_diff_output_more_complex(builddir):
     runner = CliRunner()
     result = runner.invoke(
         main.cli, ["--debug", "--path", builddir, "diff", _path, "--all"]
+        , catch_exceptions=False
     )
     assert result.exit_code == 0, result.stdout
     assert "test.py" in result.stdout
@@ -114,6 +118,7 @@ def test_diff_output_less_complex(builddir):
     runner = CliRunner()
     result = runner.invoke(
         main.cli, ["--debug", "--path", builddir, "diff", _path, "--all"]
+        , catch_exceptions=False
     )
     assert result.exit_code == 0, result.stdout
     assert "test.py" in result.stdout
@@ -133,6 +138,7 @@ def test_diff_output_loc(builddir):
     runner = CliRunner()
     result = runner.invoke(
         main.cli, ["--debug", "--path", builddir, "diff", _path, "--metrics", "raw.loc"]
+        , catch_exceptions=False
     )
     assert result.exit_code == 0, result.stdout
     assert "test.py" in result.stdout
@@ -159,7 +165,7 @@ def test_diff_output_rank(builddir):
             "--all",
             "--metrics",
             "maintainability.rank",
-        ],
+        ], catch_exceptions = False
     )
     assert result.exit_code == 0, result.stdout
     assert "test.py" in result.stdout

--- a/test/integration/test_report.py
+++ b/test/integration/test_report.py
@@ -42,6 +42,7 @@ def test_report_granular(builddir):
             "report",
             _path + ":function1",
             "cyclomatic.complexity",
+            "--message",
             "-n",
             1,
         ],
@@ -93,6 +94,23 @@ def test_report_with_message(builddir):
     assert result.exit_code == 0, result.stdout
     assert "basic test" in result.stdout
     assert "remove line" in result.stdout
+    assert "Not found" not in result.stdout
+
+
+def test_report_with_message_and_n(builddir):
+    """
+    Test that report works messages in UI and fixed number of items
+    """
+    runner = CliRunner()
+    result = runner.invoke(
+        main.cli, ["--path", builddir, "report", _path, "raw.multi", "--message", "-n 2"]
+    )
+    assert result.exit_code == 0, result.stdout
+    assert "basic test" in result.stdout
+    assert "add line" in result.stdout
+    assert result.stdout.index("basic test") < result.stdout.index("add line")
+
+    assert "remove line" not in result.stdout
     assert "Not found" not in result.stdout
 
 

--- a/test/integration/test_report.py
+++ b/test/integration/test_report.py
@@ -48,7 +48,7 @@ def test_report_granular(builddir):
         ],
     )
     assert result.exit_code == 0, result.stdout
-    assert "not found" not in result.stdout
+    assert "remove line" in result.stdout
 
 
 def test_report_not_found(builddir):

--- a/test/integration/test_report.py
+++ b/test/integration/test_report.py
@@ -48,6 +48,7 @@ def test_report_granular(builddir):
         ],
     )
     assert result.exit_code == 0, result.stdout
+    assert "not found" not in result.stdout
 
 
 def test_report_not_found(builddir):
@@ -92,6 +93,20 @@ def test_report_with_message(builddir):
     )
     assert result.exit_code == 0, result.stdout
     assert "basic test" in result.stdout
+    assert "remove line" in result.stdout
+    assert "Not found" not in result.stdout
+
+
+def test_report_with_message_and_n(builddir):
+    """
+    Test that report works messages in UI
+    """
+    runner = CliRunner()
+    result = runner.invoke(
+        main.cli, ["--path", builddir, "report", _path, "raw.multi", "--message", "-n", 1]
+    )
+    assert result.exit_code == 0, result.stdout
+    assert "basic test" not in result.stdout
     assert "remove line" in result.stdout
     assert "Not found" not in result.stdout
 

--- a/test/integration/test_report.py
+++ b/test/integration/test_report.py
@@ -103,14 +103,14 @@ def test_report_with_message_and_n(builddir):
     """
     runner = CliRunner()
     result = runner.invoke(
-        main.cli, ["--path", builddir, "report", _path, "raw.multi", "--message", "-n 2"]
+        main.cli,
+        ["--path", builddir, "report", _path, "raw.multi", "--message", "-n 2"],
     )
     assert result.exit_code == 0, result.stdout
-    assert "basic test" in result.stdout
+    assert "basic test" not in result.stdout
     assert "add line" in result.stdout
-    assert result.stdout.index("basic test") < result.stdout.index("add line")
-
-    assert "remove line" not in result.stdout
+    assert result.stdout.index("add line") > result.stdout.index("remove line")
+    assert "remove line" in result.stdout
     assert "Not found" not in result.stdout
 
 

--- a/test/integration/test_report.py
+++ b/test/integration/test_report.py
@@ -48,7 +48,6 @@ def test_report_granular(builddir):
         ],
     )
     assert result.exit_code == 0, result.stdout
-    assert "Not found" not in result.stdout
 
 
 def test_report_not_found(builddir):
@@ -93,23 +92,6 @@ def test_report_with_message(builddir):
     )
     assert result.exit_code == 0, result.stdout
     assert "basic test" in result.stdout
-    assert "remove line" in result.stdout
-    assert "Not found" not in result.stdout
-
-
-def test_report_with_message_and_n(builddir):
-    """
-    Test that report works messages in UI and fixed number of items
-    """
-    runner = CliRunner()
-    result = runner.invoke(
-        main.cli,
-        ["--path", builddir, "report", _path, "raw.multi", "--message", "-n 2"],
-    )
-    assert result.exit_code == 0, result.stdout
-    assert "basic test" not in result.stdout
-    assert "add line" in result.stdout
-    assert result.stdout.index("add line") > result.stdout.index("remove line")
     assert "remove line" in result.stdout
     assert "Not found" not in result.stdout
 

--- a/test/integration/test_state.py
+++ b/test/integration/test_state.py
@@ -1,9 +1,6 @@
 """
 This is really an integration test.
 """
-
-import os.path
-
 import pytest
 
 import wily.config
@@ -31,6 +28,10 @@ def test_index(config):
     state = wily.state.State(config)
     assert state.index
     assert state.index["git"] is not None
+
+    last_revision = state.index["git"].last_revision
+    assert last_revision.revision.message == "remove line"
+
     for revision in state.index["git"].revisions:
         assert state.index["git"][revision.revision.key]
         assert revision.revision in state.index["git"]

--- a/test/unit/test_archivers.py
+++ b/test/unit/test_archivers.py
@@ -13,13 +13,19 @@ class MockAuthor(object):
     email = "test@test.com"
 
 
+class MockStats(object):
+    files = {}
+
+
 TEST_AUTHOR = MockAuthor()
+TEST_STATS = MockStats()
 
 
 class MockCommit(object):
     name_rev = "1234 bbb"
     author = TEST_AUTHOR
     committed_date = "1/1/1990"
+    stats = TEST_STATS
 
     def __init__(self, message):
         self.message = message

--- a/test/unit/test_build_unit.py
+++ b/test/unit/test_build_unit.py
@@ -21,7 +21,7 @@ class MockArchiverCls(BaseArchiver):
                 author_email="-",  # as above
                 date=12_345_679,
                 message="None",
-                files=[]
+                files=[],
             )
         ]
 

--- a/test/unit/test_build_unit.py
+++ b/test/unit/test_build_unit.py
@@ -21,6 +21,7 @@ class MockArchiverCls(BaseArchiver):
                 author_email="-",  # as above
                 date=12_345_679,
                 message="None",
+                files=[]
             )
         ]
 

--- a/test/unit/test_cache.py
+++ b/test/unit/test_cache.py
@@ -107,6 +107,7 @@ def test_store_basic(tmpdir):
         author_email="anthony@test.com",
         date="17/01/1990",
         message="my changes",
+        files=[target_path]
     )
     fn = cache.store(config, ARCHIVER_GIT, _TEST_REVISION, _TEST_STATS)
     with open(fn) as cache_item:
@@ -130,6 +131,7 @@ def test_store_twice(tmpdir):
         author_email="anthony@test.com",
         date="17/01/1990",
         message="my changes",
+        files=[target_path]
     )
     fn = cache.store(config, ARCHIVER_GIT, _TEST_REVISION, _TEST_STATS)
     with pytest.raises(RuntimeError):
@@ -153,6 +155,7 @@ def test_store_relative_paths(tmpdir):
         author_email="anthony@test.com",
         date="17/01/1990",
         message="my changes",
+        files=[target_path]
     )
     fn = cache.store(config, ARCHIVER_GIT, _TEST_REVISION, _TEST_STATS)
     with open(fn) as cache_item:
@@ -170,7 +173,6 @@ def test_store_index(tmpdir):
     """
     config = DEFAULT_CONFIG
     cache_path = pathlib.Path(tmpdir) / ".wily"
-    target_path = pathlib.Path(tmpdir) / "foo" / "bar.py"
     cache_path.mkdir()
     config.cache_path = cache_path
     config.path = tmpdir

--- a/test/unit/test_cache.py
+++ b/test/unit/test_cache.py
@@ -107,7 +107,7 @@ def test_store_basic(tmpdir):
         author_email="anthony@test.com",
         date="17/01/1990",
         message="my changes",
-        files=[target_path]
+        files=[target_path],
     )
     fn = cache.store(config, ARCHIVER_GIT, _TEST_REVISION, _TEST_STATS)
     with open(fn) as cache_item:
@@ -131,7 +131,7 @@ def test_store_twice(tmpdir):
         author_email="anthony@test.com",
         date="17/01/1990",
         message="my changes",
-        files=[target_path]
+        files=[target_path],
     )
     fn = cache.store(config, ARCHIVER_GIT, _TEST_REVISION, _TEST_STATS)
     with pytest.raises(RuntimeError):
@@ -155,7 +155,7 @@ def test_store_relative_paths(tmpdir):
         author_email="anthony@test.com",
         date="17/01/1990",
         message="my changes",
-        files=[target_path]
+        files=[target_path],
     )
     fn = cache.store(config, ARCHIVER_GIT, _TEST_REVISION, _TEST_STATS)
     with open(fn) as cache_item:

--- a/test/unit/test_cyclomatic.py
+++ b/test/unit/test_cyclomatic.py
@@ -13,7 +13,7 @@ class MockCC(object):
 @mock.patch("wily.operators.cyclomatic.harvesters.CCHarvester", return_value=MockCC)
 def test_cyclomatic_bad_entry_data(harvester):
     MockCC.results = {"test.py": [{"complexity": 5}]}
-    op = wily.operators.cyclomatic.CyclomaticComplexityOperator(DEFAULT_CONFIG)
+    op = wily.operators.cyclomatic.CyclomaticComplexityOperator(DEFAULT_CONFIG, ["."])
     results = op.run("test.py", {})
     assert results == {"test.py": {"detailed": {}, "total": {"complexity": 0}}}
 
@@ -21,7 +21,7 @@ def test_cyclomatic_bad_entry_data(harvester):
 @mock.patch("wily.operators.cyclomatic.harvesters.CCHarvester", return_value=MockCC)
 def test_cyclomatic_error_case(harvester):
     MockCC.results = {"test.py": {"error": "bad data"}}
-    op = wily.operators.cyclomatic.CyclomaticComplexityOperator(DEFAULT_CONFIG)
+    op = wily.operators.cyclomatic.CyclomaticComplexityOperator(DEFAULT_CONFIG, ["."])
     results = op.run("test.py", {})
     assert results == {"test.py": {"detailed": {}, "total": {"complexity": 0}}}
 
@@ -29,6 +29,6 @@ def test_cyclomatic_error_case(harvester):
 @mock.patch("wily.operators.cyclomatic.harvesters.CCHarvester", return_value=MockCC)
 def test_cyclomatic_error_case_unexpected(harvester):
     MockCC.results = {"test.py": [1234]}
-    op = wily.operators.cyclomatic.CyclomaticComplexityOperator(DEFAULT_CONFIG)
+    op = wily.operators.cyclomatic.CyclomaticComplexityOperator(DEFAULT_CONFIG, ["."])
     results = op.run("test.py", {})
     assert results == {"test.py": {"detailed": {}, "total": {"complexity": 0}}}

--- a/wily/__init__.py
+++ b/wily/__init__.py
@@ -7,7 +7,7 @@ import colorlog
 import datetime
 
 
-__version__ = "1.13.1"
+__version__ = "1.14.0"
 
 _handler = colorlog.StreamHandler()
 _handler.setFormatter(colorlog.ColoredFormatter("%(log_color)s%(message)s"))

--- a/wily/__main__.py
+++ b/wily/__main__.py
@@ -2,7 +2,7 @@
 """Main command line."""
 
 import click
-
+import traceback
 from pathlib import Path
 
 from wily import logger, __version__
@@ -352,4 +352,8 @@ def handle_no_cache(context):
 
 
 if __name__ == "__main__":
-    cli()  # pragma: no cover
+    try:
+        cli()  # pragma: no cover
+    except Exception as runtime:
+        logger.error("Wily crashed!")
+        logger.debug(traceback.format_exc())

--- a/wily/archivers/__init__.py
+++ b/wily/archivers/__init__.py
@@ -6,6 +6,7 @@ Specifies a standard interface for finding revisions (versions) of a path and sw
 
 from collections import namedtuple
 from dataclasses import dataclass
+from typing import List
 
 
 class BaseArchiver(object):
@@ -52,6 +53,7 @@ class Revision:
     author_email: str
     date: str
     message: str
+    files: List[str]
 
 
 from wily.archivers.git import GitArchiver

--- a/wily/archivers/filesystem.py
+++ b/wily/archivers/filesystem.py
@@ -47,6 +47,7 @@ class FilesystemArchiver(BaseArchiver):
                 author_email="-",  # as above
                 date=int(mtime),
                 message="None",
+                files=[]
             )
         ]
 

--- a/wily/archivers/filesystem.py
+++ b/wily/archivers/filesystem.py
@@ -47,7 +47,7 @@ class FilesystemArchiver(BaseArchiver):
                 author_email="-",  # as above
                 date=int(mtime),
                 message="None",
-                files=[]
+                files=[],
             )
         ]
 

--- a/wily/archivers/git.py
+++ b/wily/archivers/git.py
@@ -80,7 +80,7 @@ class GitArchiver(BaseArchiver):
                 author_email=commit.author.email,
                 date=commit.committed_date,
                 message=commit.message,
-                files=list(commit.stats.files.keys())
+                files=list(commit.stats.files.keys()),
             )
             revisions.append(rev)
         return revisions

--- a/wily/archivers/git.py
+++ b/wily/archivers/git.py
@@ -80,7 +80,7 @@ class GitArchiver(BaseArchiver):
                 author_email=commit.author.email,
                 date=commit.committed_date,
                 message=commit.message,
-                files=commit.stats.files.keys()
+                files=list(commit.stats.files.keys())
             )
             revisions.append(rev)
         return revisions

--- a/wily/archivers/git.py
+++ b/wily/archivers/git.py
@@ -80,6 +80,7 @@ class GitArchiver(BaseArchiver):
                 author_email=commit.author.email,
                 date=commit.committed_date,
                 message=commit.message,
+                files=commit.stats.files.keys()
             )
             revisions.append(rev)
         return revisions

--- a/wily/cache.py
+++ b/wily/cache.py
@@ -124,7 +124,10 @@ def store(config, archiver, revision, stats):
             if operator_data:
                 new_operator_data = operator_data.copy()
                 for k, v in list(operator_data.items()):
-                    new_key = os.path.relpath(str(k), str(config.path))
+                    if os.path.isabs(k):
+                        new_key = os.path.relpath(str(k), str(config.path))
+                    else:
+                        new_key = str(k)
                     del new_operator_data[k]
                     new_operator_data[new_key] = v
                 del stats["operator_data"][operator]

--- a/wily/commands/build.py
+++ b/wily/commands/build.py
@@ -41,7 +41,10 @@ def run_operator(operator, revision, config, seed):
         targets = config.targets
     else:  # Only target changed files
         # TODO : Check that changed files are children of the targets
-        targets = [str(pathlib.Path(config.path) / pathlib.Path(file)) for file in revision.files]
+        targets = [
+            str(pathlib.Path(config.path) / pathlib.Path(file))
+            for file in revision.files
+        ]
 
     instance = operator.cls(config, targets)
     logger.debug(f"Running {operator.name} operator on {revision.key}, seed={seed}")
@@ -133,7 +136,7 @@ def build(config, archiver, operators):
                         prev_roots = roots
                         prev_indices = indices
                     roots = prev_roots | roots
-                    
+
                     # Copy the ir from any unchanged files from the prev revision
                     if not seed:
                         missing_indices = prev_indices - indices
@@ -146,9 +149,14 @@ def build(config, archiver, operators):
                             if operator_name not in prev_stats["operator_data"]:
                                 continue
                             # previous index may not have file either
-                            if missing not in prev_stats["operator_data"][operator_name]:
+                            if (
+                                missing
+                                not in prev_stats["operator_data"][operator_name]
+                            ):
                                 continue
-                            result[missing] = prev_stats["operator_data"][operator_name][missing]
+                            result[missing] = prev_stats["operator_data"][
+                                operator_name
+                            ][missing]
 
                     # Aggregate metrics across all root paths using the aggregate function in the metric
                     for root in roots:

--- a/wily/commands/build.py
+++ b/wily/commands/build.py
@@ -20,7 +20,7 @@ from wily.operators import resolve_operator
 
 def run_operator(operator, revision, config, seed):
     """
-    Run an operator for the multiprocessing pool
+    Run an operator for the multiprocessing pool.
 
     :param operator: The operator name
     :type  operator: ``str``

--- a/wily/commands/build.py
+++ b/wily/commands/build.py
@@ -19,7 +19,24 @@ from wily.operators import resolve_operator
 
 
 def run_operator(operator, revision, config, seed):
-    """Run an operator for the multiprocessing pool. Not called directly."""
+    """
+    Run an operator for the multiprocessing pool
+
+    :param operator: The operator name
+    :type  operator: ``str``
+
+    :param revision: The revision index
+    :type  revision: :class:`Revision`
+
+    :param config: The runtime configuration
+    :type  config: :class:`WilyConfig`
+
+    :param seed: Scan all files, not just changed
+    :type  seed: ``bool``
+
+    :rtype: ``tuple``
+    :returns: A tuple of operator name (``str``), and data (``dict``)
+    """
     if seed:
         targets = config.targets
     else:  # Only target changed files
@@ -31,7 +48,7 @@ def run_operator(operator, revision, config, seed):
 
     data = instance.run(revision, config)
 
-    # Normalise paths for non-seed passes
+    # Normalize paths for non-seed passes
     for key in list(data.keys()):
         if os.path.isabs(key):
             rel = os.path.relpath(key, config.path)
@@ -122,7 +139,7 @@ def build(config, archiver, operators):
                         missing_indices = prev_indices - indices
                         # TODO: Check existence of file path.
                         for missing in missing_indices:
-                            # dont copy aggregate keys as their values may have changed
+                            # Don't copy aggregate keys as their values may have changed
                             if missing in roots:
                                 continue
                             # previous index may not have that operator

--- a/wily/commands/build.py
+++ b/wily/commands/build.py
@@ -65,7 +65,7 @@ def build(config, archiver, operators):
     index = state.index[archiver.name]
 
     # remove existing revisions from the list
-    revisions = [revision for revision in revisions if revision not in index]
+    revisions = [revision for revision in revisions if revision not in index][::-1]
 
     logger.info(
         f"Found {len(revisions)} revisions from '{archiver.name}' archiver in '{config.path}'."
@@ -97,10 +97,12 @@ def build(config, archiver, operators):
                 for operator_name, result in data:
                     # find all unique directories in the results
                     roots = {pathlib.Path(entry).parents[0] for entry in result.keys()}
+                    indices = set(result.keys())
 
                     # For a seed run, there is no previous change set, so use current
                     if seed:
                         prev_roots = roots
+                        prev_indices = indices
 
                     logger.debug(f"Comparing {prev_roots} and {roots}")
                     roots = prev_roots | roots
@@ -125,7 +127,8 @@ def build(config, archiver, operators):
                             if len(values) > 0:
                                 result[str(root)]["total"][metric.name] = func(values)
 
-                    prev_roots = set(roots)
+                    prev_indices = indices
+                    prev_roots = roots
                     stats["operator_data"][operator_name] = result
                     bar.next()
 

--- a/wily/commands/build.py
+++ b/wily/commands/build.py
@@ -103,10 +103,15 @@ def build(config, archiver, operators):
                     if seed:
                         prev_roots = roots
                         prev_indices = indices
-
-                    logger.debug(f"Comparing {prev_roots} and {roots}")
                     roots = prev_roots | roots
+                    all_indices = prev_indices | indices
 
+                    # Copy the ir from any unchanged files from the prev revision
+                    for missing in all_indices:
+                        if missing not in indices and pathlib.Path(missing).exists():
+                            result[missing] = prev_stats["operator_data"][operator_name][missing]
+
+                    # Aggregate metrics across all root paths using the aggregate function in the metric
                     for root in roots:
                         # find all matching entries recursively
                         aggregates = [
@@ -130,6 +135,7 @@ def build(config, archiver, operators):
                     prev_indices = indices
                     prev_roots = roots
                     stats["operator_data"][operator_name] = result
+                    prev_stats = stats
                     bar.next()
 
                 seed = False

--- a/wily/commands/build.py
+++ b/wily/commands/build.py
@@ -44,6 +44,7 @@ def run_operator(operator, revision, config, seed):
         targets = [
             str(pathlib.Path(config.path) / pathlib.Path(file))
             for file in revision.files
+            if any([True for target in config.targets if target in pathlib.Path(pathlib.Path(config.path) / pathlib.Path(file)).parents])
         ]
 
     instance = operator.cls(config, targets)

--- a/wily/commands/build.py
+++ b/wily/commands/build.py
@@ -117,8 +117,8 @@ def build(config, archiver, operators):
                     targets = [
                         str(pathlib.Path(config.path) / pathlib.Path(file))
                         for file in revision.files
-                        if any([True for target in config.targets if
-                                target in pathlib.Path(pathlib.Path(config.path) / pathlib.Path(file)).parents])
+                        # if any([True for target in config.targets if
+                        #         target in pathlib.Path(pathlib.Path(config.path) / pathlib.Path(file)).parents])
                     ]
 
                 # Run each operator as a separate process

--- a/wily/commands/diff.py
+++ b/wily/commands/diff.py
@@ -42,7 +42,7 @@ def diff(config, files, metrics, changes_only=True, detail=True):
     config.targets = files
     files = list(files)
     state = State(config)
-    last_revision = state.index[state.default_archiver].revisions[-1]
+    last_revision = state.index[state.default_archiver].revisions[0]
 
     # Convert the list of metrics to a list of metric instances
     operators = {resolve_operator(metric.split(".")[0]) for metric in metrics}

--- a/wily/commands/diff.py
+++ b/wily/commands/diff.py
@@ -42,7 +42,7 @@ def diff(config, files, metrics, changes_only=True, detail=True):
     config.targets = files
     files = list(files)
     state = State(config)
-    last_revision = state.index[state.default_archiver].revisions[0]
+    last_revision = state.index[state.default_archiver].revisions[-1]
 
     # Convert the list of metrics to a list of metric instances
     operators = {resolve_operator(metric.split(".")[0]) for metric in metrics}

--- a/wily/commands/diff.py
+++ b/wily/commands/diff.py
@@ -51,7 +51,7 @@ def diff(config, files, metrics, changes_only=True, detail=True):
     results = []
 
     # Build a set of operators
-    _operators = [operator.cls(config) for operator in operators]
+    _operators = [operator.cls(config, config.targets) for operator in operators]
 
     cwd = os.getcwd()
     os.chdir(config.path)
@@ -60,7 +60,7 @@ def diff(config, files, metrics, changes_only=True, detail=True):
         data[operator.name] = operator.run(None, config)
     os.chdir(cwd)
 
-    # Write a summary table..
+    # Write a summary table
     extra = []
     for operator, metric in metrics:
         if detail and resolve_operator(operator).level == OperatorLevel.Object:
@@ -88,11 +88,11 @@ def diff(config, files, metrics, changes_only=True, detail=True):
                 current = last_revision.get(
                     config, state.default_archiver, operator, file, metric.name
                 )
-            except KeyError as e:
+            except KeyError:
                 current = "-"
             try:
                 new = get_metric(data, operator, file, metric.name)
-            except KeyError as e:
+            except KeyError:
                 new = "-"
             if new != current:
                 has_changes = True

--- a/wily/commands/index.py
+++ b/wily/commands/index.py
@@ -31,7 +31,7 @@ def index(config, include_message=False):
 
     data = []
     for archiver in state.archivers:
-        for rev in state.index[archiver].revisions:
+        for rev in state.index[archiver].revisions[::-1]:
             if include_message:
                 data.append(
                     (

--- a/wily/commands/index.py
+++ b/wily/commands/index.py
@@ -31,7 +31,7 @@ def index(config, include_message=False):
 
     data = []
     for archiver in state.archivers:
-        for rev in state.index[archiver].revisions[::-1]:
+        for rev in state.index[archiver].revisions:
             if include_message:
                 data.append(
                     (

--- a/wily/commands/report.py
+++ b/wily/commands/report.py
@@ -85,7 +85,7 @@ def report(
 
     state = State(config)
     for archiver in state.archivers:
-        history = state.index[archiver].revisions[::-1][:n]
+        history = state.index[archiver].revisions[:n][::-1]
         last = {}
         for rev in history:
             vals = []
@@ -162,7 +162,7 @@ def report(
 
         table_headers = "".join([f"<th>{header}</th>" for header in headers])
         table_content = ""
-        for line in data:
+        for line in data[::-1]:
             table_content += "<tr>"
             for element in line:
                 element = element.replace("[32m", "<span class='green-color'>")
@@ -188,6 +188,6 @@ def report(
     else:
         print(
             tabulate.tabulate(
-                headers=headers, tabular_data=data, tablefmt=console_format
+                headers=headers, tabular_data=data[::-1], tablefmt=console_format
             )
         )

--- a/wily/commands/report.py
+++ b/wily/commands/report.py
@@ -85,7 +85,7 @@ def report(
 
     state = State(config)
     for archiver in state.archivers:
-        history = state.index[archiver].revisions[:n]
+        history = state.index[archiver].revisions[::-1][:n]
         last = {}
         for rev in history:
             vals = []

--- a/wily/commands/report.py
+++ b/wily/commands/report.py
@@ -162,7 +162,7 @@ def report(
 
         table_headers = "".join([f"<th>{header}</th>" for header in headers])
         table_content = ""
-        for line in data[::-1]:
+        for line in data:
             table_content += "<tr>"
             for element in line:
                 element = element.replace("[32m", "<span class='green-color'>")
@@ -187,8 +187,7 @@ def report(
         logger.info(f"wily report was saved to {report_path}")
     else:
         print(
-            # But it still makes more sense to show the newest at the top, so reverse again
             tabulate.tabulate(
-                headers=headers, tabular_data=data[::-1], tablefmt=console_format
+                headers=headers, tabular_data=data, tablefmt=console_format
             )
         )

--- a/wily/commands/report.py
+++ b/wily/commands/report.py
@@ -85,8 +85,7 @@ def report(
 
     state = State(config)
     for archiver in state.archivers:
-        # We have to do it backwards to get the deltas between releases
-        history = state.index[archiver].revisions[:n][::-1]
+        history = state.index[archiver].revisions[:n]
         last = {}
         for rev in history:
             vals = []

--- a/wily/operators/cyclomatic.py
+++ b/wily/operators/cyclomatic.py
@@ -52,9 +52,7 @@ class CyclomaticComplexityOperator(BaseOperator):
         # TODO: Import config for harvester from .wily.cfg
         logger.debug(f"Using {targets} with {self.defaults} for CC metrics")
 
-        self.harvester = harvesters.CCHarvester(
-            targets, config=Config(**self.defaults)
-        )
+        self.harvester = harvesters.CCHarvester(targets, config=Config(**self.defaults))
 
     def run(self, module, options):
         """

--- a/wily/operators/cyclomatic.py
+++ b/wily/operators/cyclomatic.py
@@ -42,7 +42,7 @@ class CyclomaticComplexityOperator(BaseOperator):
 
     default_metric_index = 0  # MI
 
-    def __init__(self, config):
+    def __init__(self, config, targets):
         """
         Instantiate a new Cyclomatic Complexity operator.
 
@@ -50,10 +50,10 @@ class CyclomaticComplexityOperator(BaseOperator):
         :type  config: :class:`WilyConfig`
         """
         # TODO: Import config for harvester from .wily.cfg
-        logger.debug(f"Using {config.targets} with {self.defaults} for CC metrics")
+        logger.debug(f"Using {targets} with {self.defaults} for CC metrics")
 
         self.harvester = harvesters.CCHarvester(
-            config.targets, config=Config(**self.defaults)
+            targets, config=Config(**self.defaults)
         )
 
     def run(self, module, options):

--- a/wily/operators/halstead.py
+++ b/wily/operators/halstead.py
@@ -43,7 +43,7 @@ class HalsteadOperator(BaseOperator):
 
     default_metric_index = 0  # MI
 
-    def __init__(self, config):
+    def __init__(self, config, targets):
         """
         Instantiate a new HC operator.
 
@@ -51,10 +51,10 @@ class HalsteadOperator(BaseOperator):
         :type  config: :class:`WilyConfig`
         """
         # TODO : Import config from wily.cfg
-        logger.debug(f"Using {config.targets} with {self.defaults} for HC metrics")
+        logger.debug(f"Using {targets} with {self.defaults} for HC metrics")
 
         self.harvester = harvesters.HCHarvester(
-            config.targets, config=Config(**self.defaults)
+            targets, config=Config(**self.defaults)
         )
 
     def run(self, module, options):

--- a/wily/operators/halstead.py
+++ b/wily/operators/halstead.py
@@ -53,9 +53,7 @@ class HalsteadOperator(BaseOperator):
         # TODO : Import config from wily.cfg
         logger.debug(f"Using {targets} with {self.defaults} for HC metrics")
 
-        self.harvester = harvesters.HCHarvester(
-            targets, config=Config(**self.defaults)
-        )
+        self.harvester = harvesters.HCHarvester(targets, config=Config(**self.defaults))
 
     def run(self, module, options):
         """

--- a/wily/operators/maintainability.py
+++ b/wily/operators/maintainability.py
@@ -49,7 +49,7 @@ class MaintainabilityIndexOperator(BaseOperator):
 
     default_metric_index = 1  # MI
 
-    def __init__(self, config):
+    def __init__(self, config, targets):
         """
         Instantiate a new MI operator.
 
@@ -57,10 +57,10 @@ class MaintainabilityIndexOperator(BaseOperator):
         :type  config: :class:`WilyConfig`
         """
         # TODO : Import config from wily.cfg
-        logger.debug(f"Using {config.targets} with {self.defaults} for MI metrics")
+        logger.debug(f"Using {targets} with {self.defaults} for MI metrics")
 
         self.harvester = harvesters.MIHarvester(
-            config.targets, config=Config(**self.defaults)
+            targets, config=Config(**self.defaults)
         )
 
     def run(self, module, options):

--- a/wily/operators/maintainability.py
+++ b/wily/operators/maintainability.py
@@ -59,9 +59,7 @@ class MaintainabilityIndexOperator(BaseOperator):
         # TODO : Import config from wily.cfg
         logger.debug(f"Using {targets} with {self.defaults} for MI metrics")
 
-        self.harvester = harvesters.MIHarvester(
-            targets, config=Config(**self.defaults)
-        )
+        self.harvester = harvesters.MIHarvester(targets, config=Config(**self.defaults))
 
     def run(self, module, options):
         """

--- a/wily/operators/raw.py
+++ b/wily/operators/raw.py
@@ -38,7 +38,7 @@ class RawMetricsOperator(BaseOperator):
     )
     default_metric_index = 0  # LOC
 
-    def __init__(self, config):
+    def __init__(self, config, targets):
         """
         Instantiate a new raw operator.
 
@@ -46,9 +46,9 @@ class RawMetricsOperator(BaseOperator):
         :type  config: :class:`WilyConfig`
         """
         # TODO: Use config from wily.cfg for harvester
-        logger.debug(f"Using {config.targets} with {self.defaults} for Raw metrics")
+        logger.debug(f"Using {targets} with {self.defaults} for Raw metrics")
         self.harvester = harvesters.RawHarvester(
-            config.targets, config=Config(**self.defaults)
+            targets, config=Config(**self.defaults)
         )
 
     def run(self, module, options):

--- a/wily/state.py
+++ b/wily/state.py
@@ -30,7 +30,7 @@ class IndexedRevision(object):
             author_email=d["author_email"],
             date=d["date"],
             message=d["message"],
-            files=d["files"]
+            files=d["files"] if "files" in d else []
         )
         operators = d["operators"]
         return IndexedRevision(revision=rev, operators=operators)

--- a/wily/state.py
+++ b/wily/state.py
@@ -116,6 +116,15 @@ class Index(object):
         return len(self._revisions)
 
     @property
+    def last_revision(self):
+        """
+        Return the most recent revision.
+
+        :rtype: ``list`` of :class:`LazyRevision`
+        """
+        return next(iter(self._revisions.values()))
+
+    @property
     def revisions(self):
         """
         List of all the revisions.

--- a/wily/state.py
+++ b/wily/state.py
@@ -107,9 +107,7 @@ class Index(object):
             else []
         )
 
-        self._revisions = OrderedDict()
-        for d in self.data:
-            self._revisions[d["key"]] = IndexedRevision.fromdict(d)
+        self._revisions = OrderedDict({d["key"]: IndexedRevision.fromdict(d) for d in self.data})
 
     def __len__(self):
         """Use length of revisions as len."""

--- a/wily/state.py
+++ b/wily/state.py
@@ -30,7 +30,7 @@ class IndexedRevision(object):
             author_email=d["author_email"],
             date=d["date"],
             message=d["message"],
-            files=d["files"] if "files" in d else []
+            files=d["files"] if "files" in d else [],
         )
         operators = d["operators"]
         return IndexedRevision(revision=rev, operators=operators)
@@ -107,7 +107,9 @@ class Index(object):
             else []
         )
 
-        self._revisions = OrderedDict({d["key"]: IndexedRevision.fromdict(d) for d in self.data})
+        self._revisions = OrderedDict(
+            {d["key"]: IndexedRevision.fromdict(d) for d in self.data}
+        )
 
     def __len__(self):
         """Use length of revisions as len."""

--- a/wily/state.py
+++ b/wily/state.py
@@ -30,6 +30,7 @@ class IndexedRevision(object):
             author_email=d["author_email"],
             date=d["date"],
             message=d["message"],
+            files=d["files"]
         )
         operators = d["operators"]
         return IndexedRevision(revision=rev, operators=operators)


### PR DESCRIPTION
This change uses the commit metadata in git to see which files have changed then instructs radon to only inspect those changes (instead of scanning all targets).

Had to introduce a "seed" scan that would inspect all files for the first scan, then for subsequent scans, copy values if the file was unchanged.

This means that each indexed revision still has metrics for all files, it's not a delta.

Secondly, the aggregate functions had to be fully tested.