### PR TITLE
Fix Maintainability Index aim.

### DIFF
--- a/src/wily/operators/maintainability.py
+++ b/src/wily/operators/maintainability.py
@@ -43,7 +43,7 @@ class MaintainabilityIndexOperator(BaseOperator):
     metrics = (
         Metric("rank", "Maintainability Ranking", str, MetricType.Informational, mode),
         Metric(
-            "mi", "Maintainability Index", float, MetricType.AimLow, statistics.mean
+            "mi", "Maintainability Index", float, MetricType.AimHigh, statistics.mean
         ),
     )
 


### PR DESCRIPTION
Maintainability Index scale from 0 to 100 where the lower the value, the worst the Maintainability Index. The current code is set to use colors where lower is better. This patch fixes the index definition to use the correct color code, where higher values are good.

Signed-off-by: Willian Rampazzo <willianr@redhat.com>