### PR TITLE
Rank threshold option

### DIFF
--- a/docs/source/commands/rank.rst
+++ b/docs/source/commands/rank.rst
@@ -35,6 +35,12 @@ Wily rank will show the last revision by default. If you want to show a specific
 
   $ wily rank src/ --revision HEAD^2
 
+Wily rank will exit with 0 by default if no error occurs. However, you can set a custom threshold. If the total value is below the specified threshold,
+the rank command will return a non-zero exit code.
+
+.. code-block:: none
+  $ wily rank --threshold=80
+
 Command Line Usage
 ------------------
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -93,16 +93,18 @@ html_theme = "alabaster"
 # html_theme_options = {}
 
 html_theme_options = {
-    'logo': 'logo_below.png',
-    'logo_name': False,
-    'logo_text_align': "center",
-    'github_user': 'tonybaloney',
-    'github_repo': 'wily',
-    'github_banner': True,
-    'github_button': False,
-    'fixed_sidebar': True,
-    'extra_nav_links': {'wily@PyPi': "https://pypi.python.org/pypi/wily/",
-                        'wily@github': "https://github.com/tonybaloney/wily"}
+    "logo": "logo_below.png",
+    "logo_name": False,
+    "logo_text_align": "center",
+    "github_user": "tonybaloney",
+    "github_repo": "wily",
+    "github_banner": True,
+    "github_button": False,
+    "fixed_sidebar": True,
+    "extra_nav_links": {
+        "wily@PyPi": "https://pypi.python.org/pypi/wily/",
+        "wily@github": "https://github.com/tonybaloney/wily",
+    },
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,
@@ -119,7 +121,9 @@ html_static_path = ["_static"]
 # 'searchbox.html']``.
 #
 # html_sidebars = {}
-html_sidebars = {'**': ['about.html', 'navigation.html', 'searchbox.html'], }
+html_sidebars = {
+    "**": ["about.html", "navigation.html", "searchbox.html"],
+}
 
 
 # -- Options for HTMLHelp output ---------------------------------------------

--- a/src/wily/__init__.py
+++ b/src/wily/__init__.py
@@ -10,7 +10,7 @@ import datetime
 
 WILY_LOG_NAME = tempfile.mktemp(suffix="wily_log")
 
-__version__ = "1.16.0"
+__version__ = "1.17.0"
 
 _handler = colorlog.StreamHandler()
 _handler.setFormatter(colorlog.ColoredFormatter("%(log_color)s%(message)s"))

--- a/src/wily/__main__.py
+++ b/src/wily/__main__.py
@@ -166,8 +166,13 @@ def index(ctx, message):
     help="Order to show results (ascending or descending)",
     default=False,
 )
+@click.option(
+    "--threshold",
+    help="Return a non-zero exit code under the specified threshold",
+    type=click.INT,
+)
 @click.pass_context
-def rank(ctx, path, metric, revision, limit, desc):
+def rank(ctx, path, metric, revision, limit, desc, threshold):
     """
     Rank files, methods and functions in order of any metrics, e.g. complexity.
 
@@ -180,6 +185,11 @@ def rank(ctx, path, metric, revision, limit, desc):
     Rank all .py files in the index for the default metrics across all archivers
 
         $ wily rank
+
+    Rank all .py files in the index for the default metrics across all archivers
+    and return a non-zero exit code if the total is below the given threshold
+
+        $ wily rank --threshold=80
     """
     config = ctx.obj["CONFIG"]
 
@@ -195,6 +205,7 @@ def rank(ctx, path, metric, revision, limit, desc):
         metric=metric,
         revision_index=revision,
         limit=limit,
+        threshold=threshold,
         descending=desc,
     )
 

--- a/src/wily/commands/build.py
+++ b/src/wily/commands/build.py
@@ -130,8 +130,14 @@ def build(config, archiver, operators):
                 operator_data_len = 2
                 # second element in the tuple, i.e data[i][1]) has the collected data
                 for i in range(0, len(operators)):
-                    if i < len(data) and len(data[i]) >= operator_data_len and len(data[i][1]) == 0:
-                        logger.warn(f"In revision {revision.key}, for operator {operators[i].name}: No data collected")
+                    if (
+                        i < len(data)
+                        and len(data[i]) >= operator_data_len
+                        and len(data[i][1]) == 0
+                    ):
+                        logger.warn(
+                            f"In revision {revision.key}, for operator {operators[i].name}: No data collected"
+                        )
 
                 # Map the data back into a dictionary
                 for operator_name, result in data:

--- a/test/integration/test_rank.py
+++ b/test/integration/test_rank.py
@@ -129,3 +129,17 @@ def test_rank_directory_asc(builddir):
         main.cli, ["--path", builddir, "rank", "src/", "raw.comments", "--asc"]
     )
     assert result.exit_code == 0, result.stdout
+
+
+def test_rank_total_above_threshold(builddir):
+    """ Test the rank feature with total above threshold """
+    runner = CliRunner()
+    result = runner.invoke(main.cli, ["--path", builddir, "rank", "--threshold=20"])
+    assert result.exit_code == 0, result.stdout
+
+
+def test_rank_total_below_threshold(builddir):
+    """ Test the rank feature with total below threshold """
+    runner = CliRunner()
+    result = runner.invoke(main.cli, ["--path", builddir, "rank", "--threshold=100"])
+    assert result.exit_code == 1, result.stdout


### PR DESCRIPTION
Resolves: #104 

Adds support for a `--threshold` function for the `rank` command. If the total value of the used metric is below the threshold, a non-zero exit code is returned (in this case `exit_code == 1`).

@tonybaloney What do you think about the implementation? You already stated that you like the idea of a threshold option for the rank command in the issue-related discussion.