### PR TITLE
fix operators config option parsing

### DIFF
--- a/src/wily/__init__.py
+++ b/src/wily/__init__.py
@@ -1,4 +1,6 @@
 """
+A Python application for tracking, reporting on timing and complexity in tests and applications.
+
            B        BB*
          BBBB      BBB
        BBBBBB%$%*SBBB&
@@ -33,8 +35,6 @@
       %$%%BBBBBBS%$$$$$$$$%&BBBBBBS@$$$$$%%$$$$$$%$$$&B*%
       %%$%$&&S#&$$@@@@@@@@@$$@&&&@$@@@@@@@@@@@@@@@@$$%%$$
                .%%$$$$%%%$%%%%***%%%%%$%%$$$$$%%$%*&
-
-A Python application for tracking, reporting on timing and complexity in tests and applications.
 """
 import tempfile
 import colorlog

--- a/src/wily/config.py
+++ b/src/wily/config.py
@@ -46,7 +46,7 @@ class WilyConfig(object):
     A data class to reflect the configurable options within Wily.
     """
 
-    operators: List
+    operators: List[str]
     archiver: Any
     path: str
     max_revisions: int
@@ -56,7 +56,13 @@ class WilyConfig(object):
     checkout_options: dict = field(default_factory=dict)
 
     def __post_init__(self):
-        """Clone targets as a list of path."""
+        """Post process config's values.
+
+        Parse operators string to list and clone targets as a list of path.
+
+        """
+        if isinstance(self.operators, str):
+            self.operators = self._parse_to_list(self.operators)
         if self.targets is None or "":
             self.targets = [self.path]
         self._cache_path = None
@@ -73,6 +79,15 @@ class WilyConfig(object):
         """Override the cache path."""
         logger.debug(f"Setting custom cache path to {value}")
         self._cache_path = value
+
+    @staticmethod
+    def _parse_to_list(string, separator=","):
+        items = []
+        for raw_item in string.split(separator):
+            item = raw_item.strip()
+            if item:
+                items.append(item)
+        return items
 
 
 # Default values for Wily

--- a/src/wily/config.py
+++ b/src/wily/config.py
@@ -56,11 +56,7 @@ class WilyConfig(object):
     checkout_options: dict = field(default_factory=dict)
 
     def __post_init__(self):
-        """Post process config's values.
-
-        Parse operators string to list and clone targets as a list of path.
-
-        """
+        """Parse operators string to list and clone targets as a list of path."""
         if isinstance(self.operators, str):
             self.operators = self._parse_to_list(self.operators)
         if self.targets is None or "":

--- a/test/integration/test_build.py
+++ b/test/integration/test_build.py
@@ -137,6 +137,7 @@ def test_build_with_config(tmpdir, cache_path):
     config = """
     [wily]
     path = test.py
+    operators = raw, maintainability
     """
     config_path = tmppath / "wily.cfg"
     with open(config_path, "w") as config_f:

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -1,3 +1,4 @@
+import pytest
 import os.path
 
 import wily.config
@@ -39,13 +40,22 @@ def test_config_archiver(tmpdir):
     assert cfg.max_revisions == wily.config.DEFAULT_MAX_REVISIONS
 
 
-def test_config_operators(tmpdir):
+@pytest.mark.parametrize(
+    ("raw_operators", "expected_operators"),
+    [
+        ("foo,bar", ["foo", "bar"]),
+        ("foo, bar", ["foo", "bar"]),
+        ("foo, bar,", ["foo", "bar"]),
+        ("   foo,bar   , baz", ["foo", "bar", "baz"]),
+    ],
+)
+def test_config_operators(tmpdir, raw_operators, expected_operators):
     """
     Test that operators can be configured
     """
-    config = """
+    config = f"""
     [wily]
-    operators = foo,baz
+    operators = {raw_operators}
     """
     config_path = os.path.join(tmpdir, "wily.cfg")
     with open(config_path, "w") as config_f:
@@ -54,7 +64,7 @@ def test_config_operators(tmpdir):
     cfg = wily.config.load(config_path)
 
     assert cfg.archiver == wily.config.DEFAULT_ARCHIVER
-    assert cfg.operators == "foo,baz"
+    assert cfg.operators == expected_operators
     assert cfg.max_revisions == wily.config.DEFAULT_MAX_REVISIONS
 
 

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -68,7 +68,7 @@ def test_config_operators(tmpdir, raw_operators, expected_operators):
     assert cfg.max_revisions == wily.config.DEFAULT_MAX_REVISIONS
 
 
-def test_config_archiver(tmpdir):
+def test_config_max_revisions(tmpdir):
     """
     Test that an max-revisions can be configured
     """


### PR DESCRIPTION
Hi :wave:

thanks for creating and maintaining great library! 

This PR fixes `wily.cfg` `operators` option parsing to list.