### PR TITLE
Bump nbformat to 5.1.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
     "gitpython>=3.0.0,<4.0.0",
     "radon>=4.0.0,<4.1.0",
     "click>=7.0,<8.0",
-    "nbformat>=4.4.0,<4.5.0",
+    "nbformat>=5.1.3,<6.0.0",
     "colorlog>=4.0.0,<5.0.0",
     "tabulate>=0.8.2,<1.0.0",
     "plotly>=4.0.0,<5.0.0",
@@ -33,7 +33,7 @@ requires = [
     "gitpython>=3.0.0,<4.0.0",
     "radon>=4.0.0,<4.1.0",
     "click>=7.0,<8.0",
-    "nbformat>=4.4.0,<4.5.0",
+    "nbformat>=5.1.3,<6.0.0",
     "colorlog>=4.0.0,<5.0.0",
     "tabulate>=0.8.2,<1.0.0",
     "plotly>=4.0.0,<5.0.0",
@@ -56,7 +56,7 @@ wily = "wily.__main__:cli"
 legacy_tox_ini = """
 [tox]
 isolated_build = true
-envlist = py36, py37, py38
+envlist = py36, py37, py38, py39
 [testenv]
 passenv = CI TRAVIS TRAVIS_* HOME
 setenv =


### PR DESCRIPTION
`nbformat==4.4.0` is incompatible with Python 3.9 because it relies on the now-removed `encodestring` function in `base64`.

I bumped `nbformat` to 5.1.3, added Python 3.9 as a tox test environment, and ran the tests for 3.6, 3.7, 3.8, and 3.9. All passed for me.