### PR TITLE
docs: Adds a description on how to use Wily on a Github action

### DIFF
--- a/docs/source/ci.rst
+++ b/docs/source/ci.rst
@@ -65,3 +65,73 @@ Wily can be called after your tests have completed.
     - pip install wily
     - wily build src/
     - wily diff src/ -r HEAD^1
+
+
+GitHub Workflows
++++++++++
+
+When using Wily in a Github Workflows, you need to specify to the checkout step to check out the head of the branch and not the merge commit
+
+.. code-block:: yaml
+
+
+
+  name: Example Wily Pipeline on PR
+
+  on:
+    pull_request:
+  
+
+  jobs:
+
+    evaluate-complexity:
+      name: Evaluate Code complexity
+      runs-on: ubuntu-latest
+
+      steps:
+        - name: Checkout repository
+          uses: actions/checkout@v2
+          with:
+            fetch-depth: 0
+            ref: ${{ github.event.pull_request.head.ref }}
+        - name: Set up Python
+          uses: actions/setup-python@v2
+          with:
+            python-version: 3.10.0
+        - name: Install Wily
+          run: pip install wily==1.20.0
+        - name: Build cache and diff
+          id: wily
+          run: |
+            wily build my_package/ tests/
+            DIFF=$(wily diff my_package/ tests/ --no-detail -r origin/${{ github.event.pull_request.base.ref }})
+            echo "$DIFF"
+
+            # Build multine output
+            DIFF="${DIFF//'%'/'%25'}"
+            DIFF="${DIFF//$'\n'/'%0A'}"
+            DIFF="${DIFF//$'\r'/'%0D'}"
+            echo "::set-output name=diff::$DIFF"
+        - name: Find current PR
+          uses: jwalton/gh-find-current-pr@v1
+          id: findPr
+        - name: Add Wily PR Comment
+          uses: marocchino/sticky-pull-request-comment@v2
+          if: steps.findPr.outputs.number && steps.wily.outputs.diff != ''
+          with:
+            recreate: true
+            number: ${{ steps.findPr.outputs.number }}
+            message: |
+              ```
+              ${{ steps.wily.outputs.diff }}
+              ```
+        - name: Add Wily PR Comment
+          uses: marocchino/sticky-pull-request-comment@v2
+          if: steps.findPr.outputs.number && steps.wily.outputs.diff == ''
+          with:
+            recreate: true
+            number: ${{ steps.findPr.outputs.number }}
+            message: |
+              ```
+              Wily: No changes in complexity detected.
+              ```


### PR DESCRIPTION
It took me a little bit of work to understand how to run Wily correctly on each pull request on GitHub workflows, so I thought it would be useful to document this for future users