### PR TITLE
pyproject.toml: Remove dependency `mock`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,6 @@ deps =
     pytest
     pytest-cov
     codecov
-    mock
     pydocstyle
 commands =
     pytest --cov=wily


### PR DESCRIPTION
#153 makes https://pypi.org/project/mock unnecessary.
> mock is now part of the Python standard library, available as unittest.mock in Python 3.3 onwards.