### PR TITLE
refactor: apply black on wily codebase

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,7 @@ lint_python:
 
 .PHONY: lint_formatting
 lint_formatting:
-	@# TODO(skarzi): apply `black` on codebase and require it to pass
-	black --check . || true
+	black --check .
 	@# TODO(skarzi): apply `isort` on codebase and require it to pass
 	isort --check-only . || true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,13 +69,13 @@ wily = "wily.__main__:cli"
 line-length = 88
 target-version = ["py37", "py38", "py39", "py310", "py311"]
 include = '\.pyi?$'
-extent-exclude = '''
+extend-exclude = '''
 /(
     \.git
   | \.tox
   | \.venv
   | \.mypy_cache
-  | build
+  | build/
   | dist
 )/
 '''

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,8 @@ addopts =
 show-source = True
 statistics = False
 count = true
-# TODO(skarzi): fix to real value after applying `black` and `isort`
+# TODO(skarzi): fix to real value after applying `isort` and splitting too long
+# comments and docstrings into multiple lines
 max-line-length = 220
 max-complexity = 24
 exclude =
@@ -44,6 +45,9 @@ ignore =
   F841,  # local variable '<variable>' is assigned to but never used
   W292,  # no newline at end of file
   W293,  # blank line contains whitespace
+  # Following violations are ignored, because of `black`. Reference:
+  # https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#flake8
+  E203,  # whitespace before ':'
   W503,  # line break before binary operator
 
 [codespell]

--- a/src/wily/archivers/git.py
+++ b/src/wily/archivers/git.py
@@ -46,7 +46,9 @@ def get_tracked_files_dirs(repo: Repo, commit: Commit) -> Tuple[List[str], List[
     return paths, dirs
 
 
-def whatchanged(commit_a: Commit, commit_b: Commit) -> Tuple[List[str], List[str], List[str]]:
+def whatchanged(
+    commit_a: Commit, commit_b: Commit
+) -> Tuple[List[str], List[str], List[str]]:
     """Get files added, modified and deleted between commits."""
     diffs = commit_b.diff(commit_a)
     added_files = []

--- a/src/wily/cache.py
+++ b/src/wily/cache.py
@@ -101,13 +101,13 @@ def store(config, archiver, revision, stats):
 
     :param archiver: The name of the archiver type (e.g. 'git')
     :type  archiver: ``str``
-    
+
     :param revision: The revision ID
     :type  revision: ``str``
-    
+
     :param stats: The collected data
     :type  stats: ``dict``
-    
+
     :return: The absolute path to the created file
     :rtype: ``str``
 
@@ -152,7 +152,7 @@ def store_archiver_index(config, archiver, index):
 
     :param archiver: The name of the archiver type (e.g. 'git')
     :type  archiver: ``str``
-    
+
     :param index: The archiver index record
     :type  index: ``dict``
 
@@ -246,7 +246,7 @@ def get_archiver_index(config, archiver):
 
     :param archiver: The name of the archiver type (e.g. 'git')
     :type  archiver: ``str``
-    
+
     :return: The index data
     :rtype: ``dict``
     """
@@ -265,10 +265,10 @@ def get(config, archiver, revision):
 
     :param archiver: The name of the archiver type (e.g. 'git')
     :type  archiver: ``str``
-    
+
     :param revision: The revision ID
     :type  revision: ``str``
-    
+
     :return: The data record for that revision
     :rtype: ``dict``
     """

--- a/src/wily/commands/report.py
+++ b/src/wily/commands/report.py
@@ -21,6 +21,7 @@ ANSI_RED = 31
 ANSI_GREEN = 32
 ANSI_YELLOW = 33
 
+
 def report(
     config,
     path,
@@ -120,9 +121,13 @@ def report(
                     if delta == 0:
                         delta_col = delta
                     elif delta < 0:
-                        delta_col = f"\u001b[{meta['decrease_color']}m{delta:n}\u001b[0m"
+                        delta_col = (
+                            f"\u001b[{meta['decrease_color']}m{delta:n}\u001b[0m"
+                        )
                     else:
-                        delta_col = f"\u001b[{meta['increase_color']}m+{delta:n}\u001b[0m"
+                        delta_col = (
+                            f"\u001b[{meta['increase_color']}m+{delta:n}\u001b[0m"
+                        )
 
                     if meta["type"] in (int, float):
                         k = f"{val:n} ({delta_col})"

--- a/src/wily/lang.py
+++ b/src/wily/lang.py
@@ -3,7 +3,7 @@
 import gettext
 import os
 
-localedir = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'locales')
-trans = gettext.translation('messages', localedir=localedir, fallback=True)
+localedir = os.path.join(os.path.abspath(os.path.dirname(__file__)), "locales")
+trans = gettext.translation("messages", localedir=localedir, fallback=True)
 trans.install()
 _ = trans.gettext

--- a/src/wily/operators/maintainability.py
+++ b/src/wily/operators/maintainability.py
@@ -17,7 +17,7 @@ from wily.lang import _
 def mode(data):
     """
     Return the modal value of a iterable with discrete values.
-    
+
     If there is more than 1 modal value, arbitrarily return the first top n.
     """
     c = Counter(data)
@@ -42,7 +42,9 @@ class MaintainabilityIndexOperator(BaseOperator):
     }
 
     metrics = (
-        Metric("rank", _("Maintainability Ranking"), str, MetricType.Informational, mode),
+        Metric(
+            "rank", _("Maintainability Ranking"), str, MetricType.Informational, mode
+        ),
         Metric(
             "mi", _("Maintainability Index"), float, MetricType.AimHigh, statistics.mean
         ),

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -13,7 +13,7 @@ import wily.__main__ as main
 
 @pytest.fixture
 def gitdir(tmpdir):
-    """ Create a project and add code to it """
+    """Create a project and add code to it"""
     repo = Repo.init(path=tmpdir)
     tmppath = pathlib.Path(tmpdir)
     testpath = tmppath / "src" / "test.py"

--- a/test/integration/test_archiver.py
+++ b/test/integration/test_archiver.py
@@ -65,7 +65,7 @@ def test_git_end_to_end(tmpdir):
 
 
 def test_dirty_git(tmpdir):
-    """ Check that repository fails to initialise if unchecked files are in the repo """
+    """Check that repository fails to initialise if unchecked files are in the repo"""
     repo = Repo.init(path=tmpdir)
     tmppath = pathlib.Path(tmpdir)
 
@@ -95,7 +95,7 @@ def test_dirty_git(tmpdir):
 
 
 def test_detached_head(tmpdir):
-    """ Check that repo can initialize in detached head state"""
+    """Check that repo can initialize in detached head state"""
     repo = Repo.init(path=tmpdir)
     tmppath = pathlib.Path(tmpdir)
 

--- a/test/integration/test_diff.py
+++ b/test/integration/test_diff.py
@@ -24,7 +24,7 @@ def test_diff_no_path(tmpdir):
 
 
 def test_diff_output(builddir):
-    """ Test the diff feature with no changes """
+    """Test the diff feature with no changes"""
     runner = CliRunner()
     result = runner.invoke(
         main.cli, ["--debug", "--path", builddir, "diff", _path], catch_exceptions=False
@@ -34,7 +34,7 @@ def test_diff_output(builddir):
 
 
 def test_diff_output_all(builddir):
-    """ Test the diff feature with no changes and the --all flag """
+    """Test the diff feature with no changes and the --all flag"""
     runner = CliRunner()
     result = runner.invoke(
         main.cli,
@@ -46,7 +46,7 @@ def test_diff_output_all(builddir):
 
 
 def test_diff_output_bad_path(builddir):
-    """ Test the diff feature with no changes """
+    """Test the diff feature with no changes"""
     runner = CliRunner()
     result = runner.invoke(
         main.cli,
@@ -58,7 +58,7 @@ def test_diff_output_bad_path(builddir):
 
 
 def test_diff_output_remove_all(builddir):
-    """ Test the diff feature by removing all functions and classes """
+    """Test the diff feature by removing all functions and classes"""
 
     with open(pathlib.Path(builddir) / "src" / "test.py", "w") as test_py:
         test_py.write("print(1)")
@@ -73,7 +73,7 @@ def test_diff_output_remove_all(builddir):
 
 
 def test_diff_output_more_complex(builddir):
-    """ Test the diff feature by making the test file more complicated """
+    """Test the diff feature by making the test file more complicated"""
 
     complex_test = """
             import abc
@@ -108,7 +108,7 @@ def test_diff_output_more_complex(builddir):
 
 
 def test_diff_output_less_complex(builddir):
-    """ Test the diff feature by making the test file more complicated """
+    """Test the diff feature by making the test file more complicated"""
 
     simple_test = """
             import abc
@@ -137,7 +137,7 @@ def test_diff_output_less_complex(builddir):
 
 
 def test_diff_output_loc(builddir):
-    """ Test the diff feature by making the test file more complicated """
+    """Test the diff feature by making the test file more complicated"""
 
     simple_test = """print("test")"""
 
@@ -156,7 +156,7 @@ def test_diff_output_loc(builddir):
 
 
 def test_diff_output_loc_and_revision(builddir):
-    """ Test the diff feature by making the test file more complicated, particular revision """
+    """Test the diff feature by making the test file more complicated, particular revision"""
 
     simple_test = """print("test")"""
 
@@ -185,7 +185,7 @@ def test_diff_output_loc_and_revision(builddir):
 
 
 def test_diff_output_rank(builddir):
-    """ Test the diff feature by making the test file more complicated """
+    """Test the diff feature by making the test file more complicated"""
 
     simple_test = """print("test")"""
 

--- a/test/integration/test_graph.py
+++ b/test/integration/test_graph.py
@@ -27,7 +27,7 @@ def test_graph_no_cache(tmpdir, cache_path):
 
 
 def test_graph(builddir):
-    """ Test the graph feature """
+    """Test the graph feature"""
     runner = CliRunner()
     with patch.dict("os.environ", values=PATCHED_ENV, clear=True):
         result = runner.invoke(
@@ -37,7 +37,7 @@ def test_graph(builddir):
 
 
 def test_graph_all(builddir):
-    """ Test the graph feature """
+    """Test the graph feature"""
     runner = CliRunner()
     with patch.dict("os.environ", values=PATCHED_ENV, clear=True):
         result = runner.invoke(
@@ -47,7 +47,7 @@ def test_graph_all(builddir):
 
 
 def test_graph_all_with_shorthand_metric(builddir):
-    """ Test the graph feature with shorthand metric"""
+    """Test the graph feature with shorthand metric"""
     runner = CliRunner()
     with patch.dict("os.environ", values=PATCHED_ENV, clear=True):
         result = runner.invoke(
@@ -57,7 +57,7 @@ def test_graph_all_with_shorthand_metric(builddir):
 
 
 def test_graph_changes(builddir):
-    """ Test the graph feature comparing changes """
+    """Test the graph feature comparing changes"""
     runner = CliRunner()
     with patch.dict("os.environ", values=PATCHED_ENV, clear=True):
         result = runner.invoke(
@@ -67,7 +67,7 @@ def test_graph_changes(builddir):
 
 
 def test_graph_custom_x(builddir):
-    """ Test the graph feature with a custom x-axis """
+    """Test the graph feature with a custom x-axis"""
     runner = CliRunner()
     with patch.dict("os.environ", values=PATCHED_ENV, clear=True):
         result = runner.invoke(
@@ -77,7 +77,7 @@ def test_graph_custom_x(builddir):
 
 
 def test_graph_aggregate(builddir):
-    """ Test the aggregate graphs """
+    """Test the aggregate graphs"""
     runner = CliRunner()
     with patch.dict("os.environ", values=PATCHED_ENV, clear=True):
         result = runner.invoke(
@@ -87,7 +87,7 @@ def test_graph_aggregate(builddir):
 
 
 def test_graph_individual(builddir):
-    """ Test individual graphs """
+    """Test individual graphs"""
     runner = CliRunner()
     with patch.dict("os.environ", values=PATCHED_ENV, clear=True):
         result = runner.invoke(
@@ -97,7 +97,7 @@ def test_graph_individual(builddir):
 
 
 def test_graph_path(builddir):
-    """ Test the graph feature """
+    """Test the graph feature"""
     runner = CliRunner()
     with patch.dict("os.environ", values=PATCHED_ENV, clear=True):
         result = runner.invoke(
@@ -107,7 +107,7 @@ def test_graph_path(builddir):
 
 
 def test_graph_multiple(builddir):
-    """ Test the graph feature with multiple metrics """
+    """Test the graph feature with multiple metrics"""
     runner = CliRunner()
     with patch.dict("os.environ", values=PATCHED_ENV, clear=True):
         result = runner.invoke(
@@ -117,7 +117,7 @@ def test_graph_multiple(builddir):
 
 
 def test_graph_multiple_custom_x(builddir):
-    """ Test the graph feature with multiple metrics """
+    """Test the graph feature with multiple metrics"""
     runner = CliRunner()
     with patch.dict("os.environ", values=PATCHED_ENV, clear=True):
         result = runner.invoke(
@@ -137,7 +137,7 @@ def test_graph_multiple_custom_x(builddir):
 
 
 def test_graph_multiple_path(builddir):
-    """ Test the graph feature with multiple metrics """
+    """Test the graph feature with multiple metrics"""
     runner = CliRunner()
     with patch.dict("os.environ", values=PATCHED_ENV, clear=True):
         result = runner.invoke(
@@ -147,7 +147,7 @@ def test_graph_multiple_path(builddir):
 
 
 def test_graph_output(builddir):
-    """ Test the graph feature with target output file """
+    """Test the graph feature with target output file"""
     runner = CliRunner()
     with patch.dict("os.environ", values=PATCHED_ENV, clear=True):
         result = runner.invoke(
@@ -168,7 +168,7 @@ def test_graph_output(builddir):
 
 
 def test_graph_output_granular(builddir):
-    """ Test the graph feature with target output file """
+    """Test the graph feature with target output file"""
     runner = CliRunner()
     with patch.dict("os.environ", values=PATCHED_ENV, clear=True):
         result = runner.invoke(

--- a/test/integration/test_rank.py
+++ b/test/integration/test_rank.py
@@ -5,49 +5,49 @@ from git import Actor, Repo
 
 
 def test_rank_no_cache(tmpdir):
-    """ Test the rank feature with no cache """
+    """Test the rank feature with no cache"""
     runner = CliRunner()
     result = runner.invoke(main.cli, ["--path", tmpdir, "rank", "src/test.py"])
     assert result.exit_code == 1, result.stdout
 
 
 def test_rank_single_file_default_metric(builddir):
-    """ Test the rank feature with default (AimLow) metric on a single file """
+    """Test the rank feature with default (AimLow) metric on a single file"""
     runner = CliRunner()
     result = runner.invoke(main.cli, ["--path", builddir, "rank", "src/test.py"])
     assert result.exit_code == 0, result.stdout
 
 
 def test_rank_directory_default_metric(builddir):
-    """ Test the rank feature with default (AimLow) metric on a directory """
+    """Test the rank feature with default (AimLow) metric on a directory"""
     runner = CliRunner()
     result = runner.invoke(main.cli, ["--path", builddir, "rank", "src/"])
     assert result.exit_code == 0, result.stdout
 
 
 def test_rank_directory_default_metric_no_path(builddir):
-    """ Test the rank feature with no path """
+    """Test the rank feature with no path"""
     runner = CliRunner()
     result = runner.invoke(main.cli, ["--path", builddir, "rank"])
     assert result.exit_code == 0, result.stdout
 
 
 def test_rank_directory_default_metric_master(builddir):
-    """ Test the rank feature with a specific revision. """
+    """Test the rank feature with a specific revision."""
     runner = CliRunner()
     result = runner.invoke(main.cli, ["--path", builddir, "rank", "-r", "master"])
     assert result.exit_code == 0, result.stdout
 
 
 def test_rank_directory_default_invalid_revision(builddir):
-    """ Test the rank feature with an invalid revision. """
+    """Test the rank feature with an invalid revision."""
     runner = CliRunner()
     result = runner.invoke(main.cli, ["--path", builddir, "rank", "-r", "xyz"])
     assert result.exit_code == 1, result.stdout
 
 
 def test_rank_directory_default_unindexed_revision(builddir):
-    """ Test the rank feature with an unindexed revision. """
+    """Test the rank feature with an unindexed revision."""
     repo = Repo(builddir)
     with open(builddir / "test.py", "w") as test_txt:
         test_txt.write("import abc")
@@ -71,7 +71,7 @@ def test_rank_directory_default_unindexed_revision(builddir):
 
 
 def test_rank_single_file_informational(builddir):
-    """ Test the rank feature with Informational metric """
+    """Test the rank feature with Informational metric"""
     runner = CliRunner()
     result = runner.invoke(
         main.cli, ["--path", builddir, "rank", "src/test.py", "raw.loc"]
@@ -80,7 +80,7 @@ def test_rank_single_file_informational(builddir):
 
 
 def test_rank_directory_custom_metric(builddir):
-    """ Test the rank feature with AimHigh metric """
+    """Test the rank feature with AimHigh metric"""
     runner = CliRunner()
     result = runner.invoke(
         main.cli, ["--path", builddir, "rank", "src/", "raw.comments"]
@@ -89,14 +89,14 @@ def test_rank_directory_custom_metric(builddir):
 
 
 def test_rank_directory_no_path_target(builddir):
-    """ Test the rank feature with no path target """
+    """Test the rank feature with no path target"""
     runner = CliRunner()
     result = runner.invoke(main.cli, ["rank", "src/", "raw.comments"])
     assert result.exit_code == 0, result.stdout
 
 
 def test_rank_directory_limit(builddir):
-    """ Test the rank feature with limit """
+    """Test the rank feature with limit"""
     runner = CliRunner()
     result = runner.invoke(
         main.cli, ["--path", builddir, "rank", "src/", "raw.comments", "-l 2"]
@@ -105,7 +105,7 @@ def test_rank_directory_limit(builddir):
 
 
 def test_rank_directory_desc(builddir):
-    """ Test the rank feature descending order """
+    """Test the rank feature descending order"""
     runner = CliRunner()
     result = runner.invoke(
         main.cli, ["--path", builddir, "rank", "src/", "raw.comments", "--desc"]
@@ -114,7 +114,7 @@ def test_rank_directory_desc(builddir):
 
 
 def test_rank_directory_invalid_key(builddir):
-    """ Test the rank feature descending order with an invalid key """
+    """Test the rank feature descending order with an invalid key"""
     runner = CliRunner()
     result = runner.invoke(
         main.cli, ["--path", builddir, "rank", "invalid/", "raw.comments", "--desc"]
@@ -123,7 +123,7 @@ def test_rank_directory_invalid_key(builddir):
 
 
 def test_rank_directory_asc(builddir):
-    """ Test the rank feature ascending order"""
+    """Test the rank feature ascending order"""
     runner = CliRunner()
     result = runner.invoke(
         main.cli, ["--path", builddir, "rank", "src/", "raw.comments", "--asc"]
@@ -132,14 +132,14 @@ def test_rank_directory_asc(builddir):
 
 
 def test_rank_total_above_threshold(builddir):
-    """ Test the rank feature with total above threshold """
+    """Test the rank feature with total above threshold"""
     runner = CliRunner()
     result = runner.invoke(main.cli, ["--path", builddir, "rank", "--threshold=20"])
     assert result.exit_code == 0, result.stdout
 
 
 def test_rank_total_below_threshold(builddir):
-    """ Test the rank feature with total below threshold """
+    """Test the rank feature with total below threshold"""
     runner = CliRunner()
     result = runner.invoke(main.cli, ["--path", builddir, "rank", "--threshold=100"])
     assert result.exit_code == 1, result.stdout

--- a/test/integration/test_state.py
+++ b/test/integration/test_state.py
@@ -15,7 +15,7 @@ def config(builddir):
 
 
 def test_state_defaults(config):
-    """ Test the state defaults """
+    """Test the state defaults"""
     state = wily.state.State(config)
     assert state.index
     assert "git" in state.index
@@ -24,7 +24,7 @@ def test_state_defaults(config):
 
 
 def test_index(config):
-    """ Test the state index """
+    """Test the state index"""
     state = wily.state.State(config)
     assert state.index
     assert state.index["git"] is not None

--- a/test/integration/test_wily.py
+++ b/test/integration/test_wily.py
@@ -15,7 +15,7 @@ def test_list_metrics(builddir):
 
 
 def test_clean(builddir):
-    """ Test the clean feature """
+    """Test the clean feature"""
     runner = CliRunner()
     result = runner.invoke(main.cli, ["--path", builddir, "clean", "--yes"])
     assert result.exit_code == 0, result.stdout

--- a/test/unit/test_archivers.py
+++ b/test/unit/test_archivers.py
@@ -57,12 +57,12 @@ class MockRepo:
 class MockGit:
     def checkout(self, *args):
         ...
-    
+
     def execute(self, command):
-        if command[1] == 'ls-tree':
-            assert command[-1] == '123abc'
+        if command[1] == "ls-tree":
+            assert command[-1] == "123abc"
             return "\n"
-        
+
 
 @pytest.fixture
 def repo(tmpdir):

--- a/test/unit/test_cache.py
+++ b/test/unit/test_cache.py
@@ -122,7 +122,7 @@ def test_store_basic(tmpdir):
 
 @pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
 def test_store_twice(tmpdir):
-    """ Test that you can't write the same revision twice """
+    """Test that you can't write the same revision twice"""
     config = DEFAULT_CONFIG
     cache_path = pathlib.Path(tmpdir) / ".wily"
     cache_path.mkdir()


### PR DESCRIPTION
There is one action to do when this commit will be squashed to the main branch:

- [ ] add squashed commit with this PR to `.git-blame-ignore-revs` like suggested in [`black` docs](https://black.readthedocs.io/en/stable/guides/introducing_black_to_your_project.html)