### PR TITLE
Upgrade plotly from 4.x to 5.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,8 @@ jobs:
           python-version: "${{ matrix.python-version }}"
       - name: install dependencies
         run: |
-          pip install --upgrade pip wheel flit
+          python -m pip install -U pip
+          pip install wheel flit
           flit install --extras=all
       - name: lint and test
         run: make ci

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ requires = [
     "nbformat>=5.1.3,<6.0.0",
     "colorlog>=4.0.0,<5.0.0",
     "tabulate>=0.8.2,<1.0.0",
-    "plotly>=4.0.0,<5.0.0",
+    "plotly>=4.0.0,<6.0.0",
     "progress>=1.4,<2.0",
     "dataclasses; python_version == '3.6'",
 ]


### PR DESCRIPTION
I could not use Wily in my project that uses a 5.x version of Plotly because dependencies could not be resolved. This updates the Plotly dependency to be compatible with 5.x. Tests are passing and I have tested it on my project successfully with 5.10.0 so my guess is this is safe. Here's the relevant section of the release notes:

https://community.plotly.com/t/introducing-plotly-py-5-0-0-a-new-federated-jupyter-extension-icicle-charts-and-bar-chart-patterns/54039#warning-backwards-incompatible-changes-2

> Our commitment to semantic versioning requires us to make this release a major version bump (up from 4.14.3) because we are upgrading to version 2.1 of the underlying Plotly.js library, which makes some backwards-incompatible changes to older and deprecated features (see below), but we see this as a low-risk maintenance release and we expect that the vast majority of users should plan to upgrade without fearing significant issues!