### PR TITLE
Update radon dependency from 4.x to 5.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 requires = [
     "gitpython>=3.0.0,<4.0.0",
-    "radon>=4.0.0,<4.1.0",
+    "radon>=5.1,<5.2",
     "click>=7.0,<9.0",
     "nbformat>=5.1.3,<6.0.0",
     "colorlog>=4.0.0,<5.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ description-file = "README.md"
 
 [tool.flit.metadata.requires-extra]
 test = [
-    "pytest~=7.1.2",
+    "pytest~=7.2",
     "pytest-cov~=3.0.0",
 ]
 dev = [
@@ -50,7 +50,7 @@ dev = [
     "mypy~=0.961",
     "pydocstyle~=6.1.1",
     "pyupgrade~=2.37.1",
-    "safety~=2.1.0",
+    "safety~=2.3.4",
 ]
 # TODO: move here proper deps from `docs/requirements_docs.txt`
 doc = []


### PR DESCRIPTION
Radon 5.x has a smaller dependency set and a few bugfixes, see https://github.com/rubik/radon/blob/master/CHANGELOG.