### PR TITLE
ruff --select=E712,F401,F541 --fix .

### DIFF
--- a/src/wily/__main__.py
+++ b/src/wily/__main__.py
@@ -461,6 +461,6 @@ if __name__ == "__main__":  # pragma: no cover
     except Exception as runtime:
         logger.error(f"Oh no, Wily crashed! See {WILY_LOG_NAME} for information.")
         logger.info(
-            f"If you think this crash was unexpected, please raise an issue at https://github.com/tonybaloney/wily/issues and copy the log file into the issue report along with some information on what you were doing."
+            "If you think this crash was unexpected, please raise an issue at https://github.com/tonybaloney/wily/issues and copy the log file into the issue report along with some information on what you were doing."
         )
         logger.debug(traceback.format_exc())

--- a/src/wily/cache.py
+++ b/src/wily/cache.py
@@ -169,7 +169,7 @@ def store_archiver_index(config, archiver, index):
     filename = root / "index.json"
     with open(filename, "w") as out:
         out.write(json.dumps(index, indent=2))
-    logger.debug(f"Created index output")
+    logger.debug("Created index output")
     return filename
 
 

--- a/src/wily/commands/build.py
+++ b/src/wily/commands/build.py
@@ -70,7 +70,7 @@ def build(config, archiver, operators):
         revisions = archiver.revisions(config.path, config.max_revisions)
     except InvalidGitRepositoryError:
         # TODO: This logic shouldn't really be here (SoC)
-        logger.info(f"Defaulting back to the filesystem archiver, not a valid git repo")
+        logger.info("Defaulting back to the filesystem archiver, not a valid git repo")
         archiver = FilesystemArchiver(config)
         revisions = archiver.revisions(config.path, config.max_revisions)
     except Exception as e:

--- a/src/wily/commands/graph.py
+++ b/src/wily/commands/graph.py
@@ -3,7 +3,6 @@ Draw graph in HTML for a specific metric.
 
 TODO: Add multiple lines for multiple files
 """
-import pathlib
 
 import plotly.graph_objs as go
 import plotly.offline

--- a/src/wily/commands/rank.py
+++ b/src/wily/commands/rank.py
@@ -17,7 +17,7 @@ import tabulate
 from wily import format_date, format_revision, logger
 from wily.archivers import resolve_archiver
 from wily.config import DEFAULT_GRID_STYLE, DEFAULT_PATH
-from wily.operators import MetricType, resolve_metric_as_tuple
+from wily.operators import resolve_metric_as_tuple
 from wily.state import State
 
 

--- a/src/wily/commands/report.py
+++ b/src/wily/commands/report.py
@@ -7,7 +7,6 @@ Will compare the values between revisions and highlight changes in green/red.
 from pathlib import Path
 from shutil import copytree
 from string import Template
-from typing import List
 
 import tabulate
 

--- a/src/wily/state.py
+++ b/src/wily/state.py
@@ -88,7 +88,7 @@ class IndexedRevision:
             self._data = cache.get(
                 config=config, archiver=archiver, revision=self.revision.key
             )["operator_data"]
-        logger.debug(f"Fetching keys")
+        logger.debug("Fetching keys")
         return list(self._data[operator].keys())
 
     def store(self, config, archiver, stats):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2,7 +2,6 @@ import pathlib
 import shutil
 import tempfile
 from textwrap import dedent
-from time import time
 
 import pytest
 from click.testing import CliRunner

--- a/test/unit/test_archivers.py
+++ b/test/unit/test_archivers.py
@@ -50,7 +50,7 @@ class MockRepo:
     def iter_commits(self, branch, max_count, reverse):
         assert branch == self.active_branch
         assert max_count == 99
-        assert reverse == True
+        assert reverse is True
         return reversed(self.commits)
 
 


### PR DESCRIPTION
https://beta.ruff.rs
% `ruff --select=E712,F401,F541 --statistics .`
```
 1	E712	[*] Comparison to `True` should be `cond is True`
 4	F401	[*] `pathlib` imported but unused
 4	F541	[*] f-string without any placeholders
```
% `ruff --select=E712,F401,F541 --fix .`
```
Found 9 errors (9 fixed, 0 remaining).
```