### PR TITLE
Make list-metrics output stable (fix #179)

### DIFF
--- a/src/wily/operators/__init__.py
+++ b/src/wily/operators/__init__.py
@@ -112,12 +112,12 @@ OPERATOR_HALSTEAD = Operator(
 """Dictionary of all operators"""
 ALL_OPERATORS = {
     operator.name: operator
-    for operator in {
+    for operator in (
         OPERATOR_CYCLOMATIC,
         OPERATOR_MAINTAINABILITY,
         OPERATOR_RAW,
         OPERATOR_HALSTEAD,
-    }
+    )
 }
 
 


### PR DESCRIPTION
Use a tuple instead of a set to build `ALL_OPERATORS`, keeping list-metrics output stable. As discussed on #179.