### PR TITLE
Use xmlcharrefreplace to handle codec errors in html report writing (fix #182)

### DIFF
--- a/src/wily/commands/report.py
+++ b/src/wily/commands/report.py
@@ -189,7 +189,7 @@ def report(
             headers=table_headers, content=table_content
         )
 
-        with report_output.open("w") as output:
+        with report_output.open("w", errors="xmlcharrefreplace") as output:
             output.write(report_template)
 
         try:


### PR DESCRIPTION
To fix #182, use `errors="xmlcharrefreplace"` in `Path.open()` so we avoid the error and the generated HTML works.