### PR TITLE
HTML report: replace ESCAPE character (fix #184)

### DIFF
--- a/src/wily/commands/report.py
+++ b/src/wily/commands/report.py
@@ -178,10 +178,10 @@ def report(
         for line in data[::-1]:
             table_content += "<tr>"
             for element in line:
-                element = element.replace("[32m", "<span class='green-color'>")
-                element = element.replace("[31m", "<span class='red-color'>")
-                element = element.replace("[33m", "<span class='orange-color'>")
-                element = element.replace("[0m", "</span>")
+                element = element.replace("\u001b[32m", "<span class='green-color'>")
+                element = element.replace("\u001b[31m", "<span class='red-color'>")
+                element = element.replace("\u001b[33m", "<span class='orange-color'>")
+                element = element.replace("\u001b[0m", "</span>")
                 table_content += f"<td>{element}</td>"
             table_content += "</tr>"
 


### PR DESCRIPTION
Also replace ESCAPE character when replacing ANSI colors with spans, so they don't get output in the generated HTML. 

Fixes #184.