### PR TITLE
Allow report to only display revisions that have changes (fix #187)

### DIFF
--- a/src/wily/__main__.py
+++ b/src/wily/__main__.py
@@ -252,8 +252,11 @@ def rank(ctx, path, metric, revision, limit, desc, threshold):
     "--output",
     help=_("Output report to specified HTML path, e.g. reports/out.html"),
 )
+@click.option(
+    "-c", "--changes/--all", default=False, help=_("Only show revisions that have changes")
+)
 @click.pass_context
-def report(ctx, file, metrics, number, message, format, console_format, output):
+def report(ctx, file, metrics, number, message, format, console_format, output, changes):
     """Show metrics for a given file."""
     config = ctx.obj["CONFIG"]
 
@@ -284,6 +287,7 @@ def report(ctx, file, metrics, number, message, format, console_format, output):
         include_message=message,
         format=ReportFormat[format],
         console_format=console_format,
+        changes_only=changes,
     )
 
 

--- a/src/wily/__main__.py
+++ b/src/wily/__main__.py
@@ -253,10 +253,15 @@ def rank(ctx, path, metric, revision, limit, desc, threshold):
     help=_("Output report to specified HTML path, e.g. reports/out.html"),
 )
 @click.option(
-    "-c", "--changes/--all", default=False, help=_("Only show revisions that have changes")
+    "-c",
+    "--changes/--all",
+    default=False,
+    help=_("Only show revisions that have changes"),
 )
 @click.pass_context
-def report(ctx, file, metrics, number, message, format, console_format, output, changes):
+def report(
+    ctx, file, metrics, number, message, format, console_format, output, changes
+):
     """Show metrics for a given file."""
     config = ctx.obj["CONFIG"]
 

--- a/test/integration/test_report.py
+++ b/test/integration/test_report.py
@@ -121,8 +121,8 @@ def test_report_changes_only(builddir):
         main.cli, ["--path", builddir, "report", _path, "raw.multi", "-c"]
     )
     assert result.exit_code == 0, result.stdout
-    assert "basic test" in result.stdout
-    assert "remove line" in result.stdout
+    assert "basic test" not in result.stdout
+    assert "remove line" not in result.stdout
     assert "Not found" not in result.stdout
 
 

--- a/test/integration/test_report.py
+++ b/test/integration/test_report.py
@@ -112,6 +112,20 @@ def test_report_with_message_and_n(builddir):
     assert "Not found" not in result.stdout
 
 
+def test_report_changes_only(builddir):
+    """
+    Test that report works when only displaying changes
+    """
+    runner = CliRunner()
+    result = runner.invoke(
+        main.cli, ["--path", builddir, "report", _path, "raw.multi", "-c"]
+    )
+    assert result.exit_code == 0, result.stdout
+    assert "basic test" in result.stdout
+    assert "remove line" in result.stdout
+    assert "Not found" not in result.stdout
+
+
 def test_report_high_metric(builddir):
     """
     Test that report works with a build on a metric expecting high values


### PR DESCRIPTION
This add a CLI option and the path to omit lines where delta equals zero or file was not found. I've added a test, but it only checks that the CLI option works. 

Fixes #187.