### PR TITLE
Fix ruff CI checks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,6 +152,6 @@ max-complexity = 24
 "test/*" = ["D"]
 
 [tool.ruff.pylint]
-max-args = 8
-max-branches = 31
-max-statements = 91
+max-args = 10
+max-branches = 35
+max-statements = 95


### PR DESCRIPTION
Raise ruff's max-args, max-branches and max-statements because CI checks are failing (e.g. in #191) due to ruff finding the following errors:

```
src\wily\__main__.py:263:5: PLR0913 Too many arguments to function call (9 > 8)
    |
261 | )
262 | @click.pass_context
263 | def report(
264 |     ctx, file, metrics, number, message, format, console_format, output, changes
265 | ):
    |

src\wily\commands\report.py:24:5: PLR0913 Too many arguments to function call (9 > 8)
   |
24 | def report(
   |     ^^^^^^ PLR0913
25 |     config,
26 |     path,
   |

src\wily\commands\report.py:24:5: PLR0912 Too many branches (32 > 31)
   |
24 | def report(
   |     ^^^^^^ PLR0912
25 |     config,
26 |     path,
   |

src\wily\commands\report.py:24:5: PLR0915 Too many statements (94 > 91)
   |
24 | def report(
   |     ^^^^^^ PLR0915
25 |     config,
26 |     path,
   |
```

