### PR TITLE
Avoid statistics.StatisticsError if rank finds no data (fix #196)

### DIFF
--- a/src/wily/commands/rank.py
+++ b/src/wily/commands/rank.py
@@ -122,8 +122,8 @@ def rank(config, path, metric, revision_index, limit, threshold, descending):
             )
         )
 
-    if threshold and total < threshold:
-        logger.error(
-            f"Total value below the specified threshold: {total} < {threshold}"
-        )
-        exit(1)
+        if threshold and total < threshold:
+            logger.error(
+                f"Total value below the specified threshold: {total} < {threshold}"
+            )
+            exit(1)

--- a/src/wily/commands/rank.py
+++ b/src/wily/commands/rank.py
@@ -109,16 +109,18 @@ def rank(config, path, metric, revision_index, limit, threshold, descending):
     if limit:
         data = data[:limit]
 
-    # Tack on the total row at the end
-    total = metric.aggregate(rev[1] for rev in data)
-    data.append(["Total", total])
+    if data:
+        # Tack on the total row at the end
+        total = metric.aggregate(rev[1] for rev in data)
 
-    headers = ("File", metric.description)
-    print(
-        tabulate.tabulate(
-            headers=headers, tabular_data=data, tablefmt=DEFAULT_GRID_STYLE
+        data.append(["Total", total])
+
+        headers = ("File", metric.description)
+        print(
+            tabulate.tabulate(
+                headers=headers, tabular_data=data, tablefmt=DEFAULT_GRID_STYLE
+            )
         )
-    )
 
     if threshold and total < threshold:
         logger.error(

--- a/src/wily/commands/rank.py
+++ b/src/wily/commands/rank.py
@@ -109,21 +109,22 @@ def rank(config, path, metric, revision_index, limit, threshold, descending):
     if limit:
         data = data[:limit]
 
-    if data:
-        # Tack on the total row at the end
-        total = metric.aggregate(rev[1] for rev in data)
+    if not data:
+        return
 
-        data.append(["Total", total])
+    # Tack on the total row at the end
+    total = metric.aggregate(rev[1] for rev in data)
+    data.append(["Total", total])
 
-        headers = ("File", metric.description)
-        print(
-            tabulate.tabulate(
-                headers=headers, tabular_data=data, tablefmt=DEFAULT_GRID_STYLE
-            )
+    headers = ("File", metric.description)
+    print(
+        tabulate.tabulate(
+            headers=headers, tabular_data=data, tablefmt=DEFAULT_GRID_STYLE
         )
+    )
 
-        if threshold and total < threshold:
-            logger.error(
-                f"Total value below the specified threshold: {total} < {threshold}"
-            )
-            exit(1)
+    if threshold and total < threshold:
+        logger.error(
+            f"Total value below the specified threshold: {total} < {threshold}"
+        )
+        exit(1)


### PR DESCRIPTION
Only calculate mean rank and print results when some data is found by `rank()`, otherwise print nothing.

This could also be done in a way that prints an empty table with a total of 0, I'm open to doing it that way if it's preferable.