### PR TITLE
Fix some docstrings

### DIFF
--- a/src/wily/__main__.py
+++ b/src/wily/__main__.py
@@ -303,7 +303,7 @@ def report(
     "-m",
     "--metrics",
     default=None,
-    help=_("comma-seperated list of metrics, see list-metrics for choices"),
+    help=_("comma-separated list of metrics, see list-metrics for choices"),
 )
 @click.option(
     "-a/-c",

--- a/src/wily/cache.py
+++ b/src/wily/cache.py
@@ -100,10 +100,10 @@ def store(config, archiver, revision, stats):
     :type  config: :class:`wily.config.WilyConfig`
 
     :param archiver: The name of the archiver type (e.g. 'git')
-    :type  archiver: ``str``
+    :type  archiver: :class:`Archiver`
 
-    :param revision: The revision ID
-    :type  revision: ``str``
+    :param revision: The revision
+    :type  revision: :class:`Revision` or :class:`LazyRevision`
 
     :param stats: The collected data
     :type  stats: ``dict``
@@ -150,11 +150,11 @@ def store_archiver_index(config, archiver, index):
     :param config: The configuration
     :type  config: :class:`wily.config.WilyConfig`
 
-    :param archiver: The name of the archiver type (e.g. 'git')
-    :type  archiver: ``str``
+    :param archiver: The archiver to get name from (e.g. 'git')
+    :type  archiver: :class:`Archiver`
 
     :param index: The archiver index record
-    :type  index: ``dict``
+    :type  index: ``list``
 
     :rtype: `pathlib.Path`
     """
@@ -230,7 +230,7 @@ def has_archiver_index(config, archiver):
     :param archiver: The name of the archiver type (e.g. 'git')
     :type  archiver: ``str``
 
-    :return: the exist
+    :return: Whether the archiver's index exists.
     :rtype: ``bool``
     """
     root = pathlib.Path(config.cache_path) / archiver / "index.json"
@@ -263,8 +263,8 @@ def get(config, archiver, revision):
     :param config: The configuration
     :type  config: :class:`wily.config.WilyConfig`
 
-    :param archiver: The name of the archiver type (e.g. 'git')
-    :type  archiver: ``str``
+    :param archiver: The archiver to get name from (e.g. 'git')
+    :type  archiver: :class:`Archiver`
 
     :param revision: The revision ID
     :type  revision: ``str``

--- a/src/wily/cache.py
+++ b/src/wily/cache.py
@@ -99,7 +99,7 @@ def store(config, archiver, revision, stats):
     :param config: The configuration
     :type  config: :class:`wily.config.WilyConfig`
 
-    :param archiver: The name of the archiver type (e.g. 'git')
+    :param archiver: The archiver to get name from (e.g. 'git')
     :type  archiver: :class:`Archiver`
 
     :param revision: The revision

--- a/src/wily/commands/build.py
+++ b/src/wily/commands/build.py
@@ -22,8 +22,8 @@ def run_operator(operator, revision, config, targets):
     """
     Run an operator for the multiprocessing pool.
 
-    :param operator: The operator name
-    :type  operator: ``str``
+    :param operator: The operator to use
+    :type  operator: :class:`Operator`
 
     :param revision: The revision index
     :type  revision: :class:`Revision`
@@ -54,7 +54,7 @@ def run_operator(operator, revision, config, targets):
 
 def build(config, archiver, operators):
     """
-    Build the history given a archiver and collection of operators.
+    Build the history given an archiver and collection of operators.
 
     :param config: The wily configuration
     :type  config: :namedtuple:`wily.config.WilyConfig`

--- a/src/wily/commands/graph.py
+++ b/src/wily/commands/graph.py
@@ -44,6 +44,18 @@ def graph(
 
     :param output: Save report to specified path instead of opening browser.
     :type  output: ``str``
+
+    :param x_axis: Name of metric for x-axis or "history".
+    :type x_axis: ``str``
+
+    :param changes: Only graph changes.
+    :type changes: ``bool``
+
+    :param text: Show commit message inline in graph.
+    :type text: ``bool``
+
+    :param aggregate: Aggregate values for graph.
+    :type aggregate: ``bool``
     """
     logger.debug("Running graph command")
 

--- a/src/wily/commands/rank.py
+++ b/src/wily/commands/rank.py
@@ -26,23 +26,26 @@ def rank(config, path, metric, revision_index, limit, threshold, descending):
     """
     Rank command ordering files, methods or functions using metrics.
 
-    :param config: The configuration
+    :param config: The configuration.
     :type config: :class:'wily.config.WilyConfig'
 
-    :param path: The path to the file
+    :param path: The path to the file.
     :type path ''str''
 
-    :param metric: Name of the metric to report on
+    :param metric: Name of the metric to report on.
     :type metric: ''str''
 
     :param revision_index: Version of git repository to revert to.
     :type revision_index: ``str``
 
-    :param limit: Limit the number of items in the table
+    :param limit: Limit the number of items in the table.
     :type  limit: ``int``
 
-    :param threshold: For total values beneath the threshold return a non-zero exit code
+    :param threshold: For total values beneath the threshold return a non-zero exit code.
     :type  threshold: ``int``
+
+    :type descending: Rank in descending order
+    :param descending: ``bool``
 
     :return: Sorted table of all files in path, sorted in order of metric.
     """

--- a/src/wily/commands/report.py
+++ b/src/wily/commands/report.py
@@ -33,7 +33,7 @@ def report(
     changes_only=False,
 ):
     """
-    Show information about the cache and runtime.
+    Show metrics for a given file.
 
     :param config: The configuration
     :type  config: :class:`wily.config.WilyConfig`

--- a/src/wily/locales/en/LC_MESSAGES/messages.po
+++ b/src/wily/locales/en/LC_MESSAGES/messages.po
@@ -281,8 +281,8 @@ msgid "Show the differences in metrics for each file."
 msgstr ""
 
 #: src/wily/__main__.py:279
-msgid "comma-seperated list of metrics, see list-metrics for choices"
-msgstr "comma-seperated list of metrics, see list-metrics for choices"
+msgid "comma-separated list of metrics, see list-metrics for choices"
+msgstr "comma-separated list of metrics, see list-metrics for choices"
 
 #: src/wily/__main__.py:285
 msgid "Show all files, instead of changes only"

--- a/src/wily/locales/en_AU/LC_MESSAGES/messages.po
+++ b/src/wily/locales/en_AU/LC_MESSAGES/messages.po
@@ -280,8 +280,8 @@ msgid "Show the differences in metrics for each file."
 msgstr ""
 
 #: src/wily/__main__.py:279
-msgid "comma-seperated list of metrics, see list-metrics for choices"
-msgstr "comma-seperated list of metrics, see list-metrics for choices"
+msgid "comma-separated list of metrics, see list-metrics for choices"
+msgstr "comma-separated list of metrics, see list-metrics for choices"
 
 #: src/wily/__main__.py:285
 msgid "Show all files, instead of changes only"

--- a/src/wily/operators/__init__.py
+++ b/src/wily/operators/__init__.py
@@ -176,7 +176,7 @@ def resolve_metric_as_tuple(metric):
     :param metric: the metric name.
     :type  metric: ``str``
 
-    :rtype: :class:`Metric`
+    :rtype: tuple(:class:`Operator`, :class:`Metric`)
     """
     if "." in metric:
         _, metric = metric.split(".")

--- a/src/wily/operators/maintainability.py
+++ b/src/wily/operators/maintainability.py
@@ -16,7 +16,7 @@ from wily.operators import BaseOperator, Metric, MetricType
 
 def mode(data):
     """
-    Return the modal value of a iterable with discrete values.
+    Return the modal value of an iterable with discrete values.
 
     If there is more than 1 modal value, arbitrarily return the first top n.
     """

--- a/src/wily/state.py
+++ b/src/wily/state.py
@@ -191,6 +191,10 @@ class Index:
 
         :param revision: The revision.
         :type  revision: :class:`Revision` or :class:`LazyRevision`
+
+        :param operators: Operators for the revision.
+        :type operators:  ``list`` of :class:`Operator`
+
         """
         ir = IndexedRevision(
             revision=revision, operators=[operator.name for operator in operators]


### PR DESCRIPTION
Fix some docstrings for correct description, typos, typing information, consistency, etc.

For typing information, the docstring was updated to what is in code, but we could instead fix the code where it makes sense: e.g. when the docstring expects a the name of the Archiver (a str) but an Archiver is passed instead, we could actually pass the name. I'm willing to fix it either way.