### PR TITLE
Avoid using unicode characters if `sys.stdout` doesn't support them (fix #65)

### DIFF
--- a/src/wily/__main__.py
+++ b/src/wily/__main__.py
@@ -1,5 +1,6 @@
 """Main command line."""
 
+import sys
 import traceback
 from pathlib import Path
 from sys import exit
@@ -278,6 +279,10 @@ def report(
         new_output = new_output / Path(output)
     else:
         new_output = new_output / "wily_report" / "index.html"
+
+    if console_format == DEFAULT_GRID_STYLE:
+        if sys.stdout.encoding.lower() not in ("utf-8", "utf8"):
+            console_format = "grid"
 
     from wily.commands.report import report
 

--- a/src/wily/__main__.py
+++ b/src/wily/__main__.py
@@ -1,6 +1,5 @@
 """Main command line."""
 
-import sys
 import traceback
 from pathlib import Path
 from sys import exit
@@ -12,6 +11,7 @@ from wily.archivers import resolve_archiver
 from wily.cache import exists, get_default_metrics
 from wily.config import DEFAULT_CONFIG_PATH, DEFAULT_GRID_STYLE
 from wily.config import load as load_config
+from wily.helper import get_style
 from wily.helper.custom_enums import ReportFormat
 from wily.lang import _
 from wily.operators import resolve_operators
@@ -280,9 +280,7 @@ def report(
     else:
         new_output = new_output / "wily_report" / "index.html"
 
-    if console_format == DEFAULT_GRID_STYLE:
-        if sys.stdout.encoding.lower() not in ("utf-8", "utf8"):
-            console_format = "grid"
+    style = get_style(console_format)
 
     from wily.commands.report import report
 
@@ -297,7 +295,7 @@ def report(
         output=new_output,
         include_message=message,
         format=ReportFormat[format],
-        console_format=console_format,
+        console_format=style,
         changes_only=changes,
     )
 

--- a/src/wily/commands/diff.py
+++ b/src/wily/commands/diff.py
@@ -5,6 +5,7 @@ Compares metrics between uncommitted files and indexed files.
 """
 import multiprocessing
 import os
+import sys
 from pathlib import Path
 from sys import exit
 
@@ -160,9 +161,11 @@ def diff(config, files, metrics, changes_only=True, detail=True, revision=None):
     descriptions = [metric.description for operator, metric in metrics]
     headers = ("File", *descriptions)
     if len(results) > 0:
+        style = DEFAULT_GRID_STYLE
+        if sys.stdout.encoding.lower() not in ("utf-8", "utf8"):
+            style = "grid"
+
         print(
             # But it still makes more sense to show the newest at the top, so reverse again
-            tabulate.tabulate(
-                headers=headers, tabular_data=results, tablefmt=DEFAULT_GRID_STYLE
-            )
+            tabulate.tabulate(headers=headers, tabular_data=results, tablefmt=style)
         )

--- a/src/wily/commands/diff.py
+++ b/src/wily/commands/diff.py
@@ -5,7 +5,6 @@ Compares metrics between uncommitted files and indexed files.
 """
 import multiprocessing
 import os
-import sys
 from pathlib import Path
 from sys import exit
 
@@ -15,7 +14,8 @@ import tabulate
 from wily import format_date, format_revision, logger
 from wily.archivers import resolve_archiver
 from wily.commands.build import run_operator
-from wily.config import DEFAULT_GRID_STYLE, DEFAULT_PATH
+from wily.config import DEFAULT_PATH
+from wily.helper import get_style
 from wily.operators import (
     BAD_COLORS,
     GOOD_COLORS,
@@ -161,10 +161,7 @@ def diff(config, files, metrics, changes_only=True, detail=True, revision=None):
     descriptions = [metric.description for operator, metric in metrics]
     headers = ("File", *descriptions)
     if len(results) > 0:
-        style = DEFAULT_GRID_STYLE
-        if sys.stdout.encoding.lower() not in ("utf-8", "utf8"):
-            style = "grid"
-
+        style = get_style()
         print(
             # But it still makes more sense to show the newest at the top, so reverse again
             tabulate.tabulate(headers=headers, tabular_data=results, tablefmt=style)

--- a/src/wily/commands/index.py
+++ b/src/wily/commands/index.py
@@ -3,6 +3,8 @@ Print command.
 
 Print information about the wily cache and what is in the index.
 """
+import sys
+
 import tabulate
 
 from wily import MAX_MESSAGE_WIDTH, format_date, format_revision, logger
@@ -54,8 +56,8 @@ def index(config, include_message=False):
         headers = ("Revision", "Author", "Message", "Date")
     else:
         headers = ("Revision", "Author", "Date")
-    print(
-        tabulate.tabulate(
-            headers=headers, tabular_data=data, tablefmt=DEFAULT_GRID_STYLE
-        )
-    )
+
+    style = DEFAULT_GRID_STYLE
+    if sys.stdout.encoding.lower() not in ("utf-8", "utf8"):
+        style = "grid"
+    print(tabulate.tabulate(headers=headers, tabular_data=data, tablefmt=style))

--- a/src/wily/commands/index.py
+++ b/src/wily/commands/index.py
@@ -3,7 +3,6 @@ Print command.
 
 Print information about the wily cache and what is in the index.
 """
-
 import tabulate
 
 from wily import MAX_MESSAGE_WIDTH, format_date, format_revision, logger

--- a/src/wily/commands/index.py
+++ b/src/wily/commands/index.py
@@ -3,12 +3,11 @@ Print command.
 
 Print information about the wily cache and what is in the index.
 """
-import sys
 
 import tabulate
 
 from wily import MAX_MESSAGE_WIDTH, format_date, format_revision, logger
-from wily.config import DEFAULT_GRID_STYLE
+from wily.helper import get_style
 from wily.state import State
 
 
@@ -57,7 +56,5 @@ def index(config, include_message=False):
     else:
         headers = ("Revision", "Author", "Date")
 
-    style = DEFAULT_GRID_STYLE
-    if sys.stdout.encoding.lower() not in ("utf-8", "utf8"):
-        style = "grid"
+    style = get_style()
     print(tabulate.tabulate(headers=headers, tabular_data=data, tablefmt=style))

--- a/src/wily/commands/list_metrics.py
+++ b/src/wily/commands/list_metrics.py
@@ -3,19 +3,17 @@ List available metrics across all providers.
 
 TODO : Only show metrics for the operators that the cache has?
 """
-import sys
 
 import tabulate
 
-from wily.config import DEFAULT_GRID_STYLE
+from wily.helper import get_style
 from wily.operators import ALL_OPERATORS
 
 
 def list_metrics():
     """List metrics available."""
-    style = DEFAULT_GRID_STYLE
-    if sys.stdout.encoding.lower() not in ("utf-8", "utf8"):
-        style = "grid"
+    style = get_style()
+
     for name, operator in ALL_OPERATORS.items():
         print(f"{name} operator:")
         if len(operator.cls.metrics) > 0:

--- a/src/wily/commands/list_metrics.py
+++ b/src/wily/commands/list_metrics.py
@@ -3,7 +3,6 @@ List available metrics across all providers.
 
 TODO : Only show metrics for the operators that the cache has?
 """
-
 import tabulate
 
 from wily.helper import get_style
@@ -13,7 +12,6 @@ from wily.operators import ALL_OPERATORS
 def list_metrics():
     """List metrics available."""
     style = get_style()
-
     for name, operator in ALL_OPERATORS.items():
         print(f"{name} operator:")
         if len(operator.cls.metrics) > 0:

--- a/src/wily/commands/list_metrics.py
+++ b/src/wily/commands/list_metrics.py
@@ -3,6 +3,8 @@ List available metrics across all providers.
 
 TODO : Only show metrics for the operators that the cache has?
 """
+import sys
+
 import tabulate
 
 from wily.config import DEFAULT_GRID_STYLE
@@ -11,6 +13,9 @@ from wily.operators import ALL_OPERATORS
 
 def list_metrics():
     """List metrics available."""
+    style = DEFAULT_GRID_STYLE
+    if sys.stdout.encoding.lower() not in ("utf-8", "utf8"):
+        style = "grid"
     for name, operator in ALL_OPERATORS.items():
         print(f"{name} operator:")
         if len(operator.cls.metrics) > 0:
@@ -18,6 +23,6 @@ def list_metrics():
                 tabulate.tabulate(
                     headers=("Name", "Description", "Type"),
                     tabular_data=operator.cls.metrics,
-                    tablefmt=DEFAULT_GRID_STYLE,
+                    tablefmt=style,
                 )
             )

--- a/src/wily/commands/rank.py
+++ b/src/wily/commands/rank.py
@@ -9,7 +9,6 @@ TODO: Layer on Click invocation in operators section, __main__.py file
 """
 import operator as op
 import os
-import sys
 from pathlib import Path
 from sys import exit
 
@@ -18,7 +17,8 @@ import tabulate
 
 from wily import format_date, format_revision, logger
 from wily.archivers import resolve_archiver
-from wily.config import DEFAULT_GRID_STYLE, DEFAULT_PATH
+from wily.config import DEFAULT_PATH
+from wily.helper import get_style
 from wily.operators import resolve_metric_as_tuple
 from wily.state import State
 
@@ -119,9 +119,7 @@ def rank(config, path, metric, revision_index, limit, threshold, descending):
 
     headers = ("File", metric.description)
 
-    style = DEFAULT_GRID_STYLE
-    if sys.stdout.encoding.lower() not in ("utf-8", "utf8"):
-        style = "grid"
+    style = get_style()
 
     print(tabulate.tabulate(headers=headers, tabular_data=data, tablefmt=style))
 

--- a/src/wily/commands/rank.py
+++ b/src/wily/commands/rank.py
@@ -118,9 +118,7 @@ def rank(config, path, metric, revision_index, limit, threshold, descending):
     data.append(["Total", total])
 
     headers = ("File", metric.description)
-
     style = get_style()
-
     print(tabulate.tabulate(headers=headers, tabular_data=data, tablefmt=style))
 
     if threshold and total < threshold:

--- a/src/wily/commands/rank.py
+++ b/src/wily/commands/rank.py
@@ -9,6 +9,7 @@ TODO: Layer on Click invocation in operators section, __main__.py file
 """
 import operator as op
 import os
+import sys
 from pathlib import Path
 from sys import exit
 
@@ -117,11 +118,12 @@ def rank(config, path, metric, revision_index, limit, threshold, descending):
     data.append(["Total", total])
 
     headers = ("File", metric.description)
-    print(
-        tabulate.tabulate(
-            headers=headers, tabular_data=data, tablefmt=DEFAULT_GRID_STYLE
-        )
-    )
+
+    style = DEFAULT_GRID_STYLE
+    if sys.stdout.encoding.lower() not in ("utf-8", "utf8"):
+        style = "grid"
+
+    print(tabulate.tabulate(headers=headers, tabular_data=data, tablefmt=style))
 
     if threshold and total < threshold:
         logger.error(

--- a/src/wily/helper/__init__.py
+++ b/src/wily/helper/__init__.py
@@ -4,9 +4,9 @@ import sys
 from wily.config import DEFAULT_GRID_STYLE
 
 
-def get_style():
+def get_style(style=DEFAULT_GRID_STYLE):
     """Select the tablefmt style for tabulate according to what sys.stdout can handle."""
-    style = DEFAULT_GRID_STYLE
-    if sys.stdout.encoding.lower() not in ("utf-8", "utf8"):
-        style = "grid"
+    if style == DEFAULT_GRID_STYLE:
+        if sys.stdout.encoding.lower() not in ("utf-8", "utf8"):
+            style = "grid"
     return style

--- a/src/wily/helper/__init__.py
+++ b/src/wily/helper/__init__.py
@@ -1,1 +1,12 @@
 """Helper package for wily."""
+import sys
+
+from wily.config import DEFAULT_GRID_STYLE
+
+
+def get_style():
+    """Select the tablefmt style for tabulate according to what sys.stdout can handle."""
+    style = DEFAULT_GRID_STYLE
+    if sys.stdout.encoding.lower() not in ("utf-8", "utf8"):
+        style = "grid"
+    return style

--- a/test/unit/test_helper.py
+++ b/test/unit/test_helper.py
@@ -1,0 +1,26 @@
+from io import BytesIO, TextIOWrapper
+from unittest import mock
+
+from wily.config import DEFAULT_GRID_STYLE
+from wily.helper import get_style
+
+
+def test_get_style():
+    output = TextIOWrapper(BytesIO(), encoding="utf-8")
+    with mock.patch("sys.stdout", output):
+        style = get_style()
+    assert style == DEFAULT_GRID_STYLE
+
+
+def test_get_style_charmap():
+    output = TextIOWrapper(BytesIO(), encoding="charmap")
+    with mock.patch("sys.stdout", output):
+        style = get_style()
+    assert style == "grid"
+
+
+def test_get_style_charmap_not_default_grid_style():
+    output = TextIOWrapper(BytesIO(), encoding="charmap")
+    with mock.patch("sys.stdout", output):
+        style = get_style("something_else")
+    assert style == "something_else"


### PR DESCRIPTION
When piping wily's output (and in other related scenarios) in Windows, users get a `UnicodeEncodeError: 'charmap' codec can't encode characters...` error. This happens because the `DEFAULT_GRID_STYLE` is `"fancy_grid"`, which uses characters outside of what charmap can understand.

This PR introduces checks for `sys.stdout.encoding` and, if it's not UTF-8, makes wily pass `"grid"` instead of `"fancy_grid"` to tabulate as `tablefmt`. It gives comparable output with ASCII-only characters.

Output should be testable once #199 lands.

Fixes #65.