### PR TITLE
Allow output from commands to be wrapped to terminal width (fix #81)

### DIFF
--- a/src/wily/__main__.py
+++ b/src/wily/__main__.py
@@ -211,8 +211,14 @@ def index(ctx, message, wrap):
     help=_("Return a non-zero exit code under the specified threshold"),
     type=click.INT,
 )
+@click.option(
+    "-w",
+    "--wrap/--no-wrap",
+    default=False,
+    help=_("Wrap index text to fit in terminal"),
+)
 @click.pass_context
-def rank(ctx, path, metric, revision, limit, desc, threshold):
+def rank(ctx, path, metric, revision, limit, desc, threshold, wrap):
     """Rank files, methods and functions in order of any metrics, e.g. complexity."""
     config = ctx.obj["CONFIG"]
 
@@ -230,6 +236,7 @@ def rank(ctx, path, metric, revision, limit, desc, threshold):
         limit=limit,
         threshold=threshold,
         descending=desc,
+        wrap=wrap,
     )
 
 

--- a/src/wily/__main__.py
+++ b/src/wily/__main__.py
@@ -215,7 +215,7 @@ def index(ctx, message, wrap):
     "-w",
     "--wrap/--no-wrap",
     default=False,
-    help=_("Wrap index text to fit in terminal"),
+    help=_("Wrap rank text to fit in terminal"),
 )
 @click.pass_context
 def rank(ctx, path, metric, revision, limit, desc, threshold, wrap):
@@ -339,8 +339,14 @@ def report(
 @click.option(
     "-r", "--revision", help=_("Compare against specific revision"), type=click.STRING
 )
+@click.option(
+    "-w",
+    "--wrap/--no-wrap",
+    default=False,
+    help=_("Wrap diff text to fit in terminal"),
+)
 @click.pass_context
-def diff(ctx, files, metrics, all, detail, revision):
+def diff(ctx, files, metrics, all, detail, revision, wrap):
     """Show the differences in metrics for each file."""
     config = ctx.obj["CONFIG"]
 
@@ -364,6 +370,7 @@ def diff(ctx, files, metrics, all, detail, revision):
         changes_only=not all,
         detail=detail,
         revision=revision,
+        wrap=wrap,
     )
 
 

--- a/src/wily/__main__.py
+++ b/src/wily/__main__.py
@@ -259,9 +259,15 @@ def rank(ctx, path, metric, revision, limit, desc, threshold):
     default=False,
     help=_("Only show revisions that have changes"),
 )
+@click.option(
+    "-w",
+    "--wrap/--no-wrap",
+    default=False,
+    help=_("Wrap report text to fit in terminal"),
+)
 @click.pass_context
 def report(
-    ctx, file, metrics, number, message, format, console_format, output, changes
+    ctx, file, metrics, number, message, format, console_format, output, changes, wrap
 ):
     """Show metrics for a given file."""
     config = ctx.obj["CONFIG"]
@@ -294,6 +300,7 @@ def report(
         format=ReportFormat[format],
         console_format=console_format,
         changes_only=changes,
+        wrap=wrap,
     )
 
 

--- a/src/wily/__main__.py
+++ b/src/wily/__main__.py
@@ -157,7 +157,7 @@ def build(ctx, max_revisions, targets, operators, archiver):
     "-w",
     "--wrap/--no-wrap",
     default=False,
-    help=_("Wrap report text to fit in terminal"),
+    help=_("Wrap index text to fit in terminal"),
 )
 def index(ctx, message, wrap):
     """Show the history archive in the .wily/ folder."""
@@ -442,8 +442,14 @@ def clean(ctx, yes):
 
 
 @cli.command("list-metrics", help=_("""List the available metrics."""))
+@click.option(
+    "-w",
+    "--wrap/--no-wrap",
+    default=False,
+    help=_("Wrap metrics text to fit in terminal"),
+)
 @click.pass_context
-def list_metrics(ctx):
+def list_metrics(ctx, wrap):
     """List the available metrics."""
     config = ctx.obj["CONFIG"]
 
@@ -452,7 +458,7 @@ def list_metrics(ctx):
 
     from wily.commands.list_metrics import list_metrics
 
-    list_metrics()
+    list_metrics(wrap)
 
 
 @cli.command("setup", help=_("""Run a guided setup to build the wily cache."""))

--- a/src/wily/__main__.py
+++ b/src/wily/__main__.py
@@ -157,7 +157,7 @@ def build(ctx, max_revisions, targets, operators, archiver):
 @click.option(
     "-w",
     "--wrap/--no-wrap",
-    default=False,
+    default=True,
     help=_("Wrap index text to fit in terminal"),
 )
 def index(ctx, message, wrap):
@@ -215,7 +215,7 @@ def index(ctx, message, wrap):
 @click.option(
     "-w",
     "--wrap/--no-wrap",
-    default=False,
+    default=True,
     help=_("Wrap rank text to fit in terminal"),
 )
 @click.pass_context
@@ -276,7 +276,7 @@ def rank(ctx, path, metric, revision, limit, desc, threshold, wrap):
 @click.option(
     "-w",
     "--wrap/--no-wrap",
-    default=False,
+    default=True,
     help=_("Wrap report text to fit in terminal"),
 )
 @click.pass_context
@@ -345,7 +345,7 @@ def report(
 @click.option(
     "-w",
     "--wrap/--no-wrap",
-    default=False,
+    default=True,
     help=_("Wrap diff text to fit in terminal"),
 )
 @click.pass_context
@@ -462,7 +462,7 @@ def clean(ctx, yes):
 @click.option(
     "-w",
     "--wrap/--no-wrap",
-    default=False,
+    default=True,
     help=_("Wrap metrics text to fit in terminal"),
 )
 @click.pass_context

--- a/src/wily/__main__.py
+++ b/src/wily/__main__.py
@@ -153,7 +153,13 @@ def build(ctx, max_revisions, targets, operators, archiver):
 @click.option(
     "-m", "--message/--no-message", default=False, help=_("Include revision message")
 )
-def index(ctx, message):
+@click.option(
+    "-w",
+    "--wrap/--no-wrap",
+    default=False,
+    help=_("Wrap report text to fit in terminal"),
+)
+def index(ctx, message, wrap):
     """Show the history archive in the .wily/ folder."""
     config = ctx.obj["CONFIG"]
 
@@ -162,7 +168,7 @@ def index(ctx, message):
 
     from wily.commands.index import index
 
-    index(config=config, include_message=message)
+    index(config=config, include_message=message, wrap=wrap)
 
 
 @cli.command(

--- a/src/wily/commands/diff.py
+++ b/src/wily/commands/diff.py
@@ -15,6 +15,7 @@ from wily import format_date, format_revision, logger
 from wily.archivers import resolve_archiver
 from wily.commands.build import run_operator
 from wily.config import DEFAULT_GRID_STYLE, DEFAULT_PATH
+from wily.helper import get_maxcolwidth
 from wily.operators import (
     BAD_COLORS,
     GOOD_COLORS,
@@ -26,7 +27,9 @@ from wily.operators import (
 from wily.state import State
 
 
-def diff(config, files, metrics, changes_only=True, detail=True, revision=None):
+def diff(
+    config, files, metrics, changes_only=True, detail=True, revision=None, wrap=False
+):
     """
     Show the differences in metrics for each of the files.
 
@@ -159,10 +162,15 @@ def diff(config, files, metrics, changes_only=True, detail=True, revision=None):
 
     descriptions = [metric.description for operator, metric in metrics]
     headers = ("File", *descriptions)
+    maxcolwidth = get_maxcolwidth(headers, wrap)
     if len(results) > 0:
         print(
             # But it still makes more sense to show the newest at the top, so reverse again
             tabulate.tabulate(
-                headers=headers, tabular_data=results, tablefmt=DEFAULT_GRID_STYLE
+                headers=headers,
+                tabular_data=results,
+                tablefmt=DEFAULT_GRID_STYLE,
+                maxcolwidths=maxcolwidth,
+                maxheadercolwidths=maxcolwidth,
             )
         )

--- a/src/wily/commands/index.py
+++ b/src/wily/commands/index.py
@@ -7,10 +7,11 @@ import tabulate
 
 from wily import MAX_MESSAGE_WIDTH, format_date, format_revision, logger
 from wily.config import DEFAULT_GRID_STYLE
+from wily.helper import get_maxcolwidth
 from wily.state import State
 
 
-def index(config, include_message=False):
+def index(config, include_message=False, wrap=False):
     """
     Show information about the cache and runtime.
 
@@ -54,8 +55,13 @@ def index(config, include_message=False):
         headers = ("Revision", "Author", "Message", "Date")
     else:
         headers = ("Revision", "Author", "Date")
+    maxcolwidth = get_maxcolwidth(headers, wrap)
     print(
         tabulate.tabulate(
-            headers=headers, tabular_data=data, tablefmt=DEFAULT_GRID_STYLE
+            headers=headers,
+            tabular_data=data,
+            tablefmt=DEFAULT_GRID_STYLE,
+            maxcolwidths=maxcolwidth,
+            maxheadercolwidths=maxcolwidth,
         )
     )

--- a/src/wily/commands/list_metrics.py
+++ b/src/wily/commands/list_metrics.py
@@ -6,18 +6,23 @@ TODO : Only show metrics for the operators that the cache has?
 import tabulate
 
 from wily.config import DEFAULT_GRID_STYLE
+from wily.helper import get_maxcolwidth
 from wily.operators import ALL_OPERATORS
 
 
-def list_metrics():
+def list_metrics(wrap):
     """List metrics available."""
+    headers = ("Name", "Description", "Type", "Measure", "Aggregate")
+    maxcolwidth = get_maxcolwidth(headers, wrap)
     for name, operator in ALL_OPERATORS.items():
         print(f"{name} operator:")
         if len(operator.cls.metrics) > 0:
             print(
                 tabulate.tabulate(
-                    headers=("Name", "Description", "Type"),
+                    headers=headers,
                     tabular_data=operator.cls.metrics,
                     tablefmt=DEFAULT_GRID_STYLE,
+                    maxcolwidths=maxcolwidth,
+                    maxheadercolwidths=maxcolwidth,
                 )
             )

--- a/src/wily/commands/rank.py
+++ b/src/wily/commands/rank.py
@@ -18,11 +18,12 @@ import tabulate
 from wily import format_date, format_revision, logger
 from wily.archivers import resolve_archiver
 from wily.config import DEFAULT_GRID_STYLE, DEFAULT_PATH
+from wily.helper import get_maxcolwidth
 from wily.operators import resolve_metric_as_tuple
 from wily.state import State
 
 
-def rank(config, path, metric, revision_index, limit, threshold, descending):
+def rank(config, path, metric, revision_index, limit, threshold, descending, wrap):
     """
     Rank command ordering files, methods or functions using metrics.
 
@@ -117,9 +118,14 @@ def rank(config, path, metric, revision_index, limit, threshold, descending):
     data.append(["Total", total])
 
     headers = ("File", metric.description)
+    maxcolwidth = get_maxcolwidth(headers, wrap)
     print(
         tabulate.tabulate(
-            headers=headers, tabular_data=data, tablefmt=DEFAULT_GRID_STYLE
+            headers=headers,
+            tabular_data=data,
+            tablefmt=DEFAULT_GRID_STYLE,
+            maxcolwidths=maxcolwidth,
+            maxheadercolwidths=maxcolwidth,
         )
     )
 

--- a/src/wily/commands/report.py
+++ b/src/wily/commands/report.py
@@ -225,12 +225,12 @@ def get_maxcolwidth(headers):
     width = shutil.get_terminal_size()[0]
     columns = len(headers)
     if width > 125:
-        padding = 0
+        padding = 2
     elif width > 95:
         padding = 3
     else:
         padding = 5
-    maxcolwidth = width // columns - padding
+    maxcolwidth = width // columns - padding - 1
     if not width % columns:
-        maxcolwidth -= 1
-    return maxcolwidth
+        maxcolwidth -= 2
+    return max(maxcolwidth, 1)

--- a/src/wily/commands/report.py
+++ b/src/wily/commands/report.py
@@ -4,7 +4,6 @@ Report command.
 The report command gives a table of metrics for a specified list of files.
 Will compare the values between revisions and highlight changes in green/red.
 """
-import shutil
 from pathlib import Path
 from shutil import copytree
 from string import Template
@@ -12,6 +11,7 @@ from string import Template
 import tabulate
 
 from wily import MAX_MESSAGE_WIDTH, format_date, format_revision, logger
+from wily.helper import get_maxcolwidth
 from wily.helper.custom_enums import ReportFormat
 from wily.lang import _
 from wily.operators import MetricType, resolve_metric_as_tuple
@@ -219,21 +219,3 @@ def report(
                 maxheadercolwidths=maxcolwidth,
             )
         )
-
-
-def get_maxcolwidth(headers, wrap=True):
-    """Calculate the maximum column width for a given terminal width."""
-    if not wrap:
-        return
-    width = shutil.get_terminal_size()[0]
-    columns = len(headers)
-    if width > 125:
-        padding = 2
-    elif width > 95:
-        padding = 3
-    else:
-        padding = 5
-    maxcolwidth = width // columns - padding - 1
-    if not width % columns:
-        maxcolwidth -= 2
-    return max(maxcolwidth, 1)

--- a/src/wily/commands/report.py
+++ b/src/wily/commands/report.py
@@ -230,7 +230,7 @@ def get_maxcolwidth(headers):
         padding = 3
     else:
         padding = 5
-    maxcolwidth = round((width - padding * columns - width % columns) / columns)
+    maxcolwidth = width // columns - padding
     if not width % columns:
         maxcolwidth -= 1
     return maxcolwidth

--- a/src/wily/commands/report.py
+++ b/src/wily/commands/report.py
@@ -4,6 +4,7 @@ Report command.
 The report command gives a table of metrics for a specified list of files.
 Will compare the values between revisions and highlight changes in green/red.
 """
+import shutil
 from pathlib import Path
 from shutil import copytree
 from string import Template
@@ -207,8 +208,29 @@ def report(
 
         logger.info(f"wily report was saved to {report_path}")
     else:
+        maxcolwidth = get_maxcolwidth(headers)
         print(
             tabulate.tabulate(
-                headers=headers, tabular_data=data[::-1], tablefmt=console_format
+                headers=headers,
+                tabular_data=data[::-1],
+                tablefmt=console_format,
+                maxcolwidths=maxcolwidth,
+                maxheadercolwidths=maxcolwidth,
             )
         )
+
+
+def get_maxcolwidth(headers):
+    """Calculate the maximum column width for a given terminal width."""
+    width = shutil.get_terminal_size()[0]
+    columns = len(headers)
+    if width > 125:
+        padding = 0
+    elif width > 95:
+        padding = 3
+    else:
+        padding = 5
+    maxcolwidth = round((width - padding * columns - width % columns) / columns)
+    if not width % columns:
+        maxcolwidth -= 1
+    return maxcolwidth

--- a/src/wily/commands/report.py
+++ b/src/wily/commands/report.py
@@ -32,6 +32,7 @@ def report(
     format=ReportFormat.CONSOLE,
     console_format=None,
     changes_only=False,
+    wrap=False,
 ):
     """
     Show information about the cache and runtime.
@@ -208,7 +209,7 @@ def report(
 
         logger.info(f"wily report was saved to {report_path}")
     else:
-        maxcolwidth = get_maxcolwidth(headers)
+        maxcolwidth = get_maxcolwidth(headers, wrap)
         print(
             tabulate.tabulate(
                 headers=headers,
@@ -220,8 +221,10 @@ def report(
         )
 
 
-def get_maxcolwidth(headers):
+def get_maxcolwidth(headers, wrap=True):
     """Calculate the maximum column width for a given terminal width."""
+    if not wrap:
+        return
     width = shutil.get_terminal_size()[0]
     columns = len(headers)
     if width > 125:

--- a/src/wily/helper/__init__.py
+++ b/src/wily/helper/__init__.py
@@ -1,1 +1,20 @@
 """Helper package for wily."""
+import shutil
+
+
+def get_maxcolwidth(headers, wrap=True):
+    """Calculate the maximum column width for a given terminal width."""
+    if not wrap:
+        return
+    width = shutil.get_terminal_size()[0]
+    columns = len(headers)
+    if width > 125:
+        padding = 2
+    elif width > 95:
+        padding = 3
+    else:
+        padding = 5
+    maxcolwidth = width // columns - padding - 1
+    if not width % columns:
+        maxcolwidth -= 2
+    return max(maxcolwidth, 1)

--- a/src/wily/helper/__init__.py
+++ b/src/wily/helper/__init__.py
@@ -9,7 +9,7 @@ def get_maxcolwidth(headers, wrap=True):
     width = shutil.get_terminal_size()[0]
     columns = len(headers)
     if width < 80:
-        padding = columns + 1
+        padding = columns + 2
     elif width < 120:
         padding = columns - 2
     else:

--- a/src/wily/helper/__init__.py
+++ b/src/wily/helper/__init__.py
@@ -8,13 +8,11 @@ def get_maxcolwidth(headers, wrap=True):
         return
     width = shutil.get_terminal_size()[0]
     columns = len(headers)
-    if width > 125:
-        padding = 2
-    elif width > 95:
-        padding = 3
+    if width < 80:
+        padding = columns + 1
+    elif width < 120:
+        padding = columns - 2
     else:
-        padding = 5
-    maxcolwidth = width // columns - padding - 1
-    if not width % columns:
-        maxcolwidth -= 2
+        padding = columns - 4
+    maxcolwidth = (width // columns) - padding
     return max(maxcolwidth, 1)

--- a/test/integration/test_diff.py
+++ b/test/integration/test_diff.py
@@ -45,6 +45,18 @@ def test_diff_output_all(builddir):
     assert "test.py" in result.stdout
 
 
+def test_diff_output_all_wrapped(builddir):
+    """Test the diff feature with wrapping"""
+    runner = CliRunner()
+    result = runner.invoke(
+        main.cli,
+        ["--debug", "--path", builddir, "diff", _path, "--all", "--wrap"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.stdout
+    assert "test.py" in result.stdout
+
+
 def test_diff_output_bad_path(builddir):
     """Test the diff feature with no changes"""
     runner = CliRunner()

--- a/test/integration/test_index.py
+++ b/test/integration/test_index.py
@@ -34,3 +34,18 @@ def test_index_with_messages(builddir):
     assert "add line" in result.stdout
     assert "remove line" in result.stdout
     assert result.exit_code == 0, result.stdout
+
+
+def test_index_with_messages_wrapped(builddir):
+    """
+    Test that index works with a build with git commit messages and wrapping
+    """
+    runner = CliRunner()
+    result = runner.invoke(
+        main.cli, ["--path", builddir, "index", "--message", "--wrap"]
+    )
+    assert result.stdout.count("An author") == 3
+    assert "basic test" in result.stdout
+    assert "add line" in result.stdout
+    assert "remove line" in result.stdout
+    assert result.exit_code == 0, result.stdout

--- a/test/integration/test_list_metrics.py
+++ b/test/integration/test_list_metrics.py
@@ -1,0 +1,32 @@
+from click.testing import CliRunner
+
+import wily.__main__ as main
+
+
+def test_list_metrics():
+    """
+    Test that list-metrics works and is ordered
+    """
+    runner = CliRunner()
+    result = runner.invoke(main.cli, ["list-metrics"])
+    assert result.stdout.count("operator") == 4
+    assert "cyclomatic" in result.stdout
+    assert "maintainability" in result.stdout
+    assert "raw" in result.stdout
+    assert "halstead" in result.stdout
+    # Test ordering
+    i = result.stdout.index
+    assert i("cyclomatic") < i("maintainability") < i("raw") < i("halstead")
+
+
+def test_list_metrics_wrapped():
+    """
+    Test that list-metrics works with wrapping
+    """
+    runner = CliRunner()
+    result = runner.invoke(main.cli, ["list-metrics", "--wrap"])
+    assert result.stdout.count("operator") == 4
+    assert "cyclomatic" in result.stdout
+    assert "maintainability" in result.stdout
+    assert "raw" in result.stdout
+    assert "halstead" in result.stdout

--- a/test/integration/test_list_metrics.py
+++ b/test/integration/test_list_metrics.py
@@ -3,7 +3,7 @@ from click.testing import CliRunner
 import wily.__main__ as main
 
 
-def test_list_metrics():
+def test_list_metrics(builddir):
     """
     Test that list-metrics works and is ordered
     """
@@ -19,7 +19,7 @@ def test_list_metrics():
     assert i("cyclomatic") < i("maintainability") < i("raw") < i("halstead")
 
 
-def test_list_metrics_wrapped():
+def test_list_metrics_wrapped(builddir):
     """
     Test that list-metrics works with wrapping
     """

--- a/test/integration/test_rank.py
+++ b/test/integration/test_rank.py
@@ -18,6 +18,15 @@ def test_rank_single_file_default_metric(builddir):
     assert result.exit_code == 0, result.stdout
 
 
+def test_rank_single_file_default_metric_wrapped(builddir):
+    """Test the rank feature with default metric and wrapping"""
+    runner = CliRunner()
+    result = runner.invoke(
+        main.cli, ["--path", builddir, "rank", "--wrap", "src/test.py"]
+    )
+    assert result.exit_code == 0, result.stdout
+
+
 def test_rank_directory_default_metric(builddir):
     """Test the rank feature with default (AimLow) metric on a directory"""
     runner = CliRunner()

--- a/test/integration/test_report.py
+++ b/test/integration/test_report.py
@@ -138,6 +138,18 @@ def test_report_high_metric(builddir):
     assert "Not found" not in result.stdout
 
 
+def test_report_wrapped(builddir):
+    """
+    Test that report works with wrapping
+    """
+    runner = CliRunner()
+    result = runner.invoke(
+        main.cli, ["--path", builddir, "report", "--wrap", _path, "raw.comments"]
+    )
+    assert result.exit_code == 0, result.stdout
+    assert "Not found" not in result.stdout
+
+
 def test_report_short_metric(builddir):
     """
     Test that report works with a build on shorthand metric

--- a/test/unit/test_helper.py
+++ b/test/unit/test_helper.py
@@ -1,0 +1,77 @@
+from unittest import mock
+
+import tabulate
+
+from wily.helper import get_maxcolwidth
+
+SHORT_DATA = [list("abcdefgh"), list("abcdefgh")]
+
+LONG_DATA = [["long_data"] * 8, ["long_data"] * 8]
+
+HUGE_DATA = [["huge_data"] * 18, ["huge_data"] * 18]
+
+
+def test_get_maxcolwidth_no_wrap():
+    result = get_maxcolwidth([], False)
+    assert result is None
+
+
+def test_get_maxcolwidth_wrap_short():
+    for width in range(35, 100):
+        mock_get_terminal_size = mock.Mock(return_value=(width, 24))
+        mock_shutil = mock.Mock(get_terminal_size=mock_get_terminal_size)
+
+        with mock.patch("wily.helper.shutil", mock_shutil):
+            result = get_maxcolwidth(SHORT_DATA[0], True)
+        as_table = tabulate.tabulate(
+            tabular_data=SHORT_DATA,
+            tablefmt="grid",
+            maxcolwidths=result,
+            maxheadercolwidths=result,
+        )
+
+        line = as_table.splitlines()[0]
+        assert len(line) < width
+        assert len(line) >= width / 3
+
+
+def test_get_maxcolwidth_wrap_long():
+    for width in range(35, 290):
+        mock_get_terminal_size = mock.Mock(return_value=(width, 24))
+        mock_shutil = mock.Mock(get_terminal_size=mock_get_terminal_size)
+
+        with mock.patch("wily.helper.shutil", mock_shutil):
+            result = get_maxcolwidth(LONG_DATA[0], True)
+        as_table = tabulate.tabulate(
+            tabular_data=LONG_DATA,
+            tablefmt="grid",
+            maxcolwidths=result,
+            maxheadercolwidths=result,
+        )
+
+        line = as_table.splitlines()[0]
+        assert len(line) < width
+        if width < 290:
+            assert len(line) >= width / 3
+
+
+def test_get_maxcolwidth_wrap_huge():
+    for width in range(75, 450):
+        mock_get_terminal_size = mock.Mock(return_value=(width, 24))
+        mock_shutil = mock.Mock(get_terminal_size=mock_get_terminal_size)
+
+        with mock.patch("wily.helper.shutil", mock_shutil):
+            result = get_maxcolwidth(HUGE_DATA[0], True)
+        as_table = tabulate.tabulate(
+            tabular_data=HUGE_DATA,
+            tablefmt="grid",
+            maxcolwidths=result,
+            maxheadercolwidths=result,
+        )
+
+        line = as_table.splitlines()[0]
+        assert len(line) < width
+        if width < 220:
+            assert len(line) >= width / 3
+        else:
+            assert len(line) >= width / 4

--- a/test/unit/test_helper.py
+++ b/test/unit/test_helper.py
@@ -6,9 +6,16 @@ from wily.helper import get_maxcolwidth
 
 SHORT_DATA = [list("abcdefgh"), list("abcdefgh")]
 
+MEDIUM_DATA = [["medium_data"] * 2, ["medium_data"] * 2]
+
 LONG_DATA = [["long_data"] * 8, ["long_data"] * 8]
 
 HUGE_DATA = [["huge_data"] * 18, ["huge_data"] * 18]
+
+LONG_LINE_MEDIUM_DATA = [
+    ["long_line_for_some_medium_data"] * 2,
+    ["long_line_for_some_medium_data"] * 2,
+]
 
 
 def test_get_maxcolwidth_no_wrap():
@@ -33,6 +40,50 @@ def test_get_maxcolwidth_wrap_short():
         line = as_table.splitlines()[0]
         assert len(line) < width
         assert len(line) >= width / 3
+
+
+def test_get_maxcolwidth_wrap_medium():
+    for width in range(35, 100):
+        mock_get_terminal_size = mock.Mock(return_value=(width, 24))
+        mock_shutil = mock.Mock(get_terminal_size=mock_get_terminal_size)
+
+        with mock.patch("wily.helper.shutil", mock_shutil):
+            result = get_maxcolwidth(MEDIUM_DATA[0], True)
+        as_table = tabulate.tabulate(
+            tabular_data=MEDIUM_DATA,
+            tablefmt="grid",
+            maxcolwidths=result,
+            maxheadercolwidths=result,
+        )
+
+        line = as_table.splitlines()[0]
+        print(line)
+        print(width, len(line))
+        assert len(line) < width
+        if width < 85:
+            assert len(line) >= width / 3
+
+
+def test_get_maxcolwidth_wrap_long_line_medium():
+    for width in range(35, 100):
+        mock_get_terminal_size = mock.Mock(return_value=(width, 24))
+        mock_shutil = mock.Mock(get_terminal_size=mock_get_terminal_size)
+
+        with mock.patch("wily.helper.shutil", mock_shutil):
+            result = get_maxcolwidth(LONG_LINE_MEDIUM_DATA[0], True)
+        as_table = tabulate.tabulate(
+            tabular_data=LONG_LINE_MEDIUM_DATA,
+            tablefmt="grid",
+            maxcolwidths=result,
+            maxheadercolwidths=result,
+        )
+
+        line = as_table.splitlines()[0]
+        print(line)
+        print(width, len(line))
+        assert len(line) < width
+        if width < 85:
+            assert len(line) >= width / 3
 
 
 def test_get_maxcolwidth_wrap_long():


### PR DESCRIPTION
Adds `--wrap` to commands, so output that is too wide for a given terminal width is wrapped inside the table cells. 

Uses `shutil.get_terminal_size()` to get terminal size, then calculates an approximation of maximum column width and passes that as [`maxcolwidths` and `maxheadercolwidths` parameters to tabulate.tabulate(](https://github.com/astanin/python-tabulate#automating-multilines)).

Adds some tests, but not exact output testing.

Fixes #81, except for very narrow terminals with lots of metrics.