### PR TITLE
Fix graph not displaying filenames as line labels

### DIFF
--- a/src/wily/commands/graph.py
+++ b/src/wily/commands/graph.py
@@ -137,7 +137,7 @@ def graph(
             x=x,
             y=y,
             mode="lines+markers+text" if text else "lines+markers",
-            name=f"{path}",
+            name=f"{path_}",
             ids=state.index[state.default_archiver].revision_keys,
             text=labels,
             marker={


### PR DESCRIPTION
When fixing #190, I missed a place where `path` should become `path_` and that leads to wrong line labels in graph. This PR fixes the issue introduced in #191.