### PR TITLE
Avoid report erroring out if there is no data to show

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,4 +154,4 @@ max-complexity = 24
 [tool.ruff.pylint]
 max-args = 10
 max-branches = 35
-max-statements = 95
+max-statements = 100

--- a/src/wily/commands/report.py
+++ b/src/wily/commands/report.py
@@ -162,6 +162,10 @@ def report(
                             *vals,
                         )
                     )
+    if not data:
+        logger.error(f"No data found for {path} with changes={changes_only}.")
+        return
+
     descriptions = [meta["title"] for meta in metric_metas]
     if include_message:
         headers = (_("Revision"), _("Message"), _("Author"), _("Date"), *descriptions)

--- a/test/integration/test_report.py
+++ b/test/integration/test_report.py
@@ -112,7 +112,7 @@ def test_report_with_message_and_n(builddir):
     assert "Not found" not in result.stdout
 
 
-def test_report_changes_only(builddir):
+def test_report_changes_only(builddir, caplog):
     """
     Test that report works when only displaying changes
     """
@@ -124,6 +124,7 @@ def test_report_changes_only(builddir):
     assert "basic test" not in result.stdout
     assert "remove line" not in result.stdout
     assert "Not found" not in result.stdout
+    assert "No data found" in caplog.text
 
 
 def test_report_high_metric(builddir):


### PR DESCRIPTION
When running `wily report --changes`, it's possible to end up with no data to show, which results in an `IndexError` from tabulate. In this PR the same [guard-clause](https://blog.boot.dev/clean-code/guard-clauses/#guard-clauses) strategy of #197 is used to avoid that, while logging an error explaining why no output is generated.

This fixes an error that surfaced in #201, but I can't see why it would be triggered by that change. 