### PR TITLE
Handle sys.stdout.encoding being None in get_style()

### DIFF
--- a/src/wily/helper/__init__.py
+++ b/src/wily/helper/__init__.py
@@ -24,6 +24,8 @@ def get_maxcolwidth(headers, wrap=True):
 def get_style(style=DEFAULT_GRID_STYLE):
     """Select the tablefmt style for tabulate according to what sys.stdout can handle."""
     if style == DEFAULT_GRID_STYLE:
-        if sys.stdout.encoding.lower() not in ("utf-8", "utf8"):
+        encoding = sys.stdout.encoding
+        # StringIO has encoding=None, but it handles utf-8 fine.
+        if encoding is not None and encoding.lower() not in ("utf-8", "utf8"):
             style = "grid"
     return style

--- a/test/unit/test_helper.py
+++ b/test/unit/test_helper.py
@@ -1,4 +1,4 @@
-from io import BytesIO, TextIOWrapper
+from io import BytesIO, StringIO, TextIOWrapper
 from unittest import mock
 
 import tabulate
@@ -149,3 +149,10 @@ def test_get_style_charmap_not_default_grid_style():
     with mock.patch("sys.stdout", output):
         style = get_style("something_else")
     assert style == "something_else"
+
+
+def test_get_style_none():
+    output = StringIO()  # output.encoding is None
+    with mock.patch("sys.stdout", output):
+        style = get_style()
+    assert style == "fancy_grid"


### PR DESCRIPTION
If `sys.stdout` is a `StringIO` instance, `sys.stdout.encoding` will be `None` and `wily.helper.get_style()` will error out due to trying to call `.lower()` on it. This PR adds a check to handle that case.

Found while updating #199, due to a test that mocked stdout in this way.