### PR TITLE
Annotate core functions and remove sphinx style argument types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: 3.11
+    - name: install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        pip install flit
+        flit install --extras=all
     - uses: jakebailey/pyright-action@v1
       with:
         working-directory: src

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,3 +57,11 @@ jobs:
     - uses: actions/checkout@v3
     - run: pip install --user ruff
     - run: ruff --format=github .
+
+  pyright:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: jakebailey/pyright-action@v1
+      with:
+        working-directory: src

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ compile_messages:
 lint_python:
 	ruff .
 	@# TODO(skarzi): fix type hints and require `mypy` to pass
-	mypy . || true
+	mypy --install-types --non-interactive src || true
 
 .PHONY: lint_formatting
 lint_formatting:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "click>=7.0,<9.0",
     "nbformat>=5.1.3,<6.0.0",
     "colorlog>=4.0.0,<5.0.0",
-    "tabulate>=0.8.2,<1.0.0",
+    "tabulate>=0.9.0,<1.0.0",
     "plotly>=4.0.0,<6.0.0",
     "progress>=1.4,<2.0",
     "dataclasses; python_version == '3.6'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
-    "gitpython>=3.0.0,<4.0.0",
+    "gitpython>=3.1.32,<4.0.0",
     "radon>=5.1,<5.2",
     "click>=7.0,<9.0",
     "nbformat>=5.1.3,<6.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dynamic=["version", "description"]
 [project.optional-dependencies]
 test = [
     "pytest~=7.2",
-    "pytest-cov~=3.0.0",
+    "pytest-cov~=4.1.0",
 ]
 dev = [
     "black~=22.6.0",

--- a/src/wily/__init__.py
+++ b/src/wily/__init__.py
@@ -60,16 +60,16 @@ logger.addHandler(_filehandler)
 MAX_MESSAGE_WIDTH = 50
 
 
-def format_date(timestamp):
+def format_date(timestamp: float) -> str:
     """Reusable timestamp -> date."""
     return datetime.date.fromtimestamp(timestamp).isoformat()
 
 
-def format_datetime(timestamp):
+def format_datetime(timestamp: float) -> str:
     """Reusable timestamp -> datetime."""
     return datetime.datetime.fromtimestamp(timestamp).isoformat()
 
 
-def format_revision(sha):
+def format_revision(sha: str) -> str:
     """Return a shorter git sha."""
     return sha[:7]

--- a/src/wily/__main__.py
+++ b/src/wily/__main__.py
@@ -503,7 +503,7 @@ def handle_no_cache(context):
 
 if __name__ == "__main__":  # pragma: no cover
     try:
-        cli()
+        cli()  # type: ignore
     except Exception as runtime:
         logger.error(f"Oh no, Wily crashed! See {WILY_LOG_NAME} for information.")
         logger.info(

--- a/src/wily/__main__.py
+++ b/src/wily/__main__.py
@@ -9,8 +9,8 @@ import click
 from wily import WILY_LOG_NAME, __version__, logger
 from wily.archivers import resolve_archiver
 from wily.cache import exists, get_default_metrics
-from wily.config import DEFAULT_CONFIG_PATH, DEFAULT_GRID_STYLE
 from wily.config import load as load_config
+from wily.defaults import DEFAULT_CONFIG_PATH, DEFAULT_GRID_STYLE
 from wily.helper import get_style
 from wily.helper.custom_enums import ReportFormat
 from wily.lang import _

--- a/src/wily/archivers/__init__.py
+++ b/src/wily/archivers/__init__.py
@@ -4,9 +4,10 @@ Archivers module.
 Specifies a standard interface for finding revisions (versions) of a path and switching to them.
 """
 
-from collections import namedtuple
 from dataclasses import dataclass
-from typing import List
+from typing import List, NamedTuple
+
+from wily.config import WilyConfig
 
 
 @dataclass
@@ -27,6 +28,9 @@ class Revision:
 
 class BaseArchiver:
     """Abstract Archiver Class."""
+
+    def __init__(self, config: WilyConfig, *args, **kwargs):
+        ...
 
     def revisions(self, path: str, max_revisions: int) -> List[Revision]:
         """
@@ -76,7 +80,15 @@ from wily.archivers.filesystem import FilesystemArchiver
 from wily.archivers.git import GitArchiver
 
 """Type for an operator"""
-Archiver = namedtuple("Archiver", "name cls description")
+
+
+class Archiver(NamedTuple):
+    name: str
+    cls: BaseArchiver
+    description: str
+
+    def __str__(self):
+        return self.name
 
 
 """Git Operator defined in `wily.archivers.git`"""

--- a/src/wily/archivers/__init__.py
+++ b/src/wily/archivers/__init__.py
@@ -7,6 +7,8 @@ Specifies a standard interface for finding revisions (versions) of a path and sw
 from dataclasses import dataclass
 from typing import Any, Dict, Generic, List, Optional, Type, TypeVar
 
+from wily.config.types import WilyConfig
+
 
 @dataclass
 class Revision:

--- a/src/wily/archivers/__init__.py
+++ b/src/wily/archivers/__init__.py
@@ -5,7 +5,7 @@ Specifies a standard interface for finding revisions (versions) of a path and sw
 """
 
 from dataclasses import dataclass
-from typing import Any, Dict, List, NamedTuple, Optional
+from typing import Any, Dict, Generic, List, NamedTuple, Optional, Type, TypeVar
 
 from wily.config import WilyConfig
 
@@ -28,6 +28,8 @@ class Revision:
 
 class BaseArchiver:
     """Abstract Archiver Class."""
+
+    name: str
 
     def __init__(self, config: WilyConfig):
         ...
@@ -78,10 +80,11 @@ from wily.archivers.git import GitArchiver
 
 """Type for an operator"""
 
+T = TypeVar("T", bound=Type)
 
-class Archiver(NamedTuple):
+class Archiver(NamedTuple, Generic[T]):
     name: str
-    cls: type[BaseArchiver]
+    cls: T
     description: str
 
     def __str__(self):

--- a/src/wily/archivers/__init__.py
+++ b/src/wily/archivers/__init__.py
@@ -5,7 +5,7 @@ Specifies a standard interface for finding revisions (versions) of a path and sw
 """
 
 from dataclasses import dataclass
-from typing import List, NamedTuple
+from typing import Any, Dict, List, NamedTuple, Optional
 
 from wily.config import WilyConfig
 
@@ -15,9 +15,9 @@ class Revision:
     """Represents a revision in the archiver."""
 
     key: str
-    author_name: str
-    author_email: str
-    date: str
+    author_name: Optional[str]
+    author_email: Optional[str]
+    date: int
     message: str
     tracked_files: List[str]
     tracked_dirs: List[str]
@@ -29,7 +29,7 @@ class Revision:
 class BaseArchiver:
     """Abstract Archiver Class."""
 
-    def __init__(self, config: WilyConfig, *args, **kwargs):
+    def __init__(self, config: WilyConfig):
         ...
 
     def revisions(self, path: str, max_revisions: int) -> List[Revision]:
@@ -47,15 +47,12 @@ class BaseArchiver:
         """
         raise NotImplementedError
 
-    def checkout(self, revision: Revision, **options):
+    def checkout(self, revision: Revision, options: Dict[Any, Any]) -> None:
         """
         Checkout a specific revision.
 
         :param revision: The revision identifier.
-        :type  revision: :class:`Revision`
-
         :param options: Any additional options.
-        :type  options: ``dict``
         """
         raise NotImplementedError
 
@@ -84,7 +81,7 @@ from wily.archivers.git import GitArchiver
 
 class Archiver(NamedTuple):
     name: str
-    cls: BaseArchiver
+    cls: type[BaseArchiver]
     description: str
 
     def __str__(self):

--- a/src/wily/archivers/__init__.py
+++ b/src/wily/archivers/__init__.py
@@ -32,6 +32,7 @@ class BaseArchiver:
     name: str
 
     def __init__(self, config: WilyConfig):
+        """Initialise the archiver."""
         ...
 
     def revisions(self, path: str, max_revisions: int) -> List[Revision]:
@@ -82,12 +83,16 @@ from wily.archivers.git import GitArchiver
 
 T = TypeVar("T", bound=Type)
 
+
 class Archiver(NamedTuple, Generic[T]):
+    """Holder for archivers."""
+
     name: str
     cls: T
     description: str
 
     def __str__(self):
+        """Return the name of the archiver."""
         return self.name
 
 

--- a/src/wily/archivers/__init__.py
+++ b/src/wily/archivers/__init__.py
@@ -40,13 +40,9 @@ class BaseArchiver:
         Get the list of revisions.
 
         :param path: the path to target.
-        :type  path: ``str``
-
         :param max_revisions: the maximum number of revisions.
-        :type  max_revisions: ``int``
 
         :return: A list of revisions.
-        :rtype: ``list`` of :class:`Revision`
         """
         ...
 
@@ -79,7 +75,7 @@ class BaseArchiver:
 from wily.archivers.filesystem import FilesystemArchiver
 from wily.archivers.git import GitArchiver
 
-"""Type for an operator"""
+"""Type for an Archiver"""
 
 T = TypeVar("T")
 
@@ -102,7 +98,7 @@ class Archiver(Generic[T]):
         return self.name
 
 
-"""Git Operator defined in `wily.archivers.git`"""
+"""Git Archiver defined in `wily.archivers.git`"""
 ARCHIVER_GIT = Archiver(
     name="git", archiver_cls=GitArchiver, description="Git archiver"
 )

--- a/src/wily/archivers/__init__.py
+++ b/src/wily/archivers/__init__.py
@@ -46,7 +46,7 @@ class BaseArchiver:
         :return: A list of revisions.
         :rtype: ``list`` of :class:`Revision`
         """
-        raise NotImplementedError
+        ...
 
     def checkout(self, revision: Revision, options: Dict[Any, Any]) -> None:
         """
@@ -55,7 +55,7 @@ class BaseArchiver:
         :param revision: The revision identifier.
         :param options: Any additional options.
         """
-        raise NotImplementedError
+        ...
 
     def finish(self):
         """Clean up any state if processing completed/failed."""
@@ -71,7 +71,7 @@ class BaseArchiver:
         :return: An instance of revision.
         :rtype: Instance of :class:`Revision`
         """
-        raise NotImplementedError
+        ...
 
 
 from wily.archivers.filesystem import FilesystemArchiver

--- a/src/wily/archivers/__init__.py
+++ b/src/wily/archivers/__init__.py
@@ -88,13 +88,13 @@ class Archiver(Generic[T]):
     """Holder for archivers."""
 
     name: str
-    cls: Type[T]
+    archiver_cls: Type[T]
     description: str
 
-    def __init__(self, name: str, cls: Type[T], description: str):
+    def __init__(self, name: str, archiver_cls: Type[T], description: str):
         """Initialise the archiver."""
         self.name = name
-        self.cls = cls
+        self.archiver_cls = archiver_cls
         self.description = description
 
     def __str__(self):
@@ -103,11 +103,15 @@ class Archiver(Generic[T]):
 
 
 """Git Operator defined in `wily.archivers.git`"""
-ARCHIVER_GIT = Archiver(name="git", cls=GitArchiver, description="Git archiver")
+ARCHIVER_GIT = Archiver(
+    name="git", archiver_cls=GitArchiver, description="Git archiver"
+)
 
 """Filesystem archiver"""
 ARCHIVER_FILESYSTEM = Archiver(
-    name="filesystem", cls=FilesystemArchiver, description="Filesystem archiver"
+    name="filesystem",
+    archiver_cls=FilesystemArchiver,
+    description="Filesystem archiver",
 )
 
 """Set of all available archivers"""

--- a/src/wily/archivers/__init__.py
+++ b/src/wily/archivers/__init__.py
@@ -7,8 +7,6 @@ Specifies a standard interface for finding revisions (versions) of a path and sw
 from dataclasses import dataclass
 from typing import Any, Dict, Generic, List, NamedTuple, Optional, Type, TypeVar
 
-from wily.config import WilyConfig
-
 
 @dataclass
 class Revision:
@@ -31,7 +29,7 @@ class BaseArchiver:
 
     name: str
 
-    def __init__(self, config: WilyConfig):
+    def __init__(self, config: "WilyConfig"):
         """Initialise the archiver."""
         ...
 
@@ -81,15 +79,21 @@ from wily.archivers.git import GitArchiver
 
 """Type for an operator"""
 
-T = TypeVar("T", bound=Type)
+T = TypeVar("T")
 
 
-class Archiver(NamedTuple, Generic[T]):
+class Archiver(Generic[T]):
     """Holder for archivers."""
 
     name: str
-    cls: T
+    cls: Type[T]
     description: str
+
+    def __init__(self, name: str, cls: Type[T], description: str):
+        """Initialise the archiver."""
+        self.name = name
+        self.cls = cls
+        self.description = description
 
     def __str__(self):
         """Return the name of the archiver."""

--- a/src/wily/archivers/__init__.py
+++ b/src/wily/archivers/__init__.py
@@ -5,7 +5,7 @@ Specifies a standard interface for finding revisions (versions) of a path and sw
 """
 
 from dataclasses import dataclass
-from typing import Any, Dict, Generic, List, NamedTuple, Optional, Type, TypeVar
+from typing import Any, Dict, Generic, List, Optional, Type, TypeVar
 
 
 @dataclass

--- a/src/wily/archivers/filesystem.py
+++ b/src/wily/archivers/filesystem.py
@@ -9,7 +9,6 @@ import os.path
 from typing import Any, Dict, List
 
 from wily.archivers import BaseArchiver, Revision
-from wily.config import WilyConfig
 
 logger = logging.getLogger(__name__)
 
@@ -19,12 +18,11 @@ class FilesystemArchiver(BaseArchiver):
 
     name = "filesystem"
 
-    def __init__(self, config: WilyConfig):
+    def __init__(self, config: "WilyConfig"):
         """
         Instantiate a new Filesystem Archiver.
 
         :param config: The wily configuration
-        :type  config: :class:`wily.config.WilyConfig`
         """
         self.config = config
 

--- a/src/wily/archivers/filesystem.py
+++ b/src/wily/archivers/filesystem.py
@@ -9,6 +9,7 @@ import os.path
 from typing import Any, Dict, List
 
 from wily.archivers import BaseArchiver, Revision
+from wily.config.types import WilyConfig
 
 logger = logging.getLogger(__name__)
 

--- a/src/wily/archivers/filesystem.py
+++ b/src/wily/archivers/filesystem.py
@@ -9,6 +9,7 @@ import os.path
 from typing import List
 
 from wily.archivers import BaseArchiver, Revision
+from wily.config import WilyConfig
 
 logger = logging.getLogger(__name__)
 
@@ -18,7 +19,7 @@ class FilesystemArchiver(BaseArchiver):
 
     name = "filesystem"
 
-    def __init__(self, config):
+    def __init__(self, config: WilyConfig):
         """
         Instantiate a new Filesystem Archiver.
 

--- a/src/wily/archivers/filesystem.py
+++ b/src/wily/archivers/filesystem.py
@@ -6,7 +6,7 @@ Implementation of the archiver API for a standard directory (no revisions)
 import hashlib
 import logging
 import os.path
-from typing import List
+from typing import Any, Dict, List
 
 from wily.archivers import BaseArchiver, Revision
 from wily.config import WilyConfig
@@ -33,13 +33,8 @@ class FilesystemArchiver(BaseArchiver):
         Get the list of revisions.
 
         :param path: the path to target.
-        :type  path: ``str``
-
         :param max_revisions: the maximum number of revisions.
-        :type  max_revisions: ``int``
-
         :return: A list of revisions.
-        :rtype: ``list`` of :class:`Revision`
         """
         mtime = os.path.getmtime(path)
         key = hashlib.sha1(str(mtime).encode()).hexdigest()[:7]
@@ -58,15 +53,12 @@ class FilesystemArchiver(BaseArchiver):
             )
         ]
 
-    def checkout(self, revision: Revision, options):
+    def checkout(self, revision: Revision, options: Dict[Any, Any]) -> None:
         """
         Checkout a specific revision.
 
         :param revision: The revision identifier.
-        :type  revision: :class:`Revision`
-
         :param options: Any additional options.
-        :type  options: ``dict``
         """
         # effectively noop since there are no revision
         pass

--- a/src/wily/archivers/git.py
+++ b/src/wily/archivers/git.py
@@ -11,7 +11,6 @@ from git import Commit
 from git.repo import Repo
 
 from wily.archivers import BaseArchiver, Revision
-from wily.config import WilyConfig
 
 logger = logging.getLogger(__name__)
 
@@ -79,12 +78,11 @@ class GitArchiver(BaseArchiver):
 
     name = "git"
 
-    def __init__(self, config: WilyConfig):
+    def __init__(self, config: "WilyConfig"):
         """
         Instantiate a new Git Archiver.
 
         :param config: The wily configuration
-        :type  config: :class:`wily.config.WilyConfig`
         """
         try:
             self.repo = Repo(config.path)

--- a/src/wily/archivers/git.py
+++ b/src/wily/archivers/git.py
@@ -11,6 +11,7 @@ from git import Commit
 from git.repo import Repo
 
 from wily.archivers import BaseArchiver, Revision
+from wily.config.types import WilyConfig
 
 logger = logging.getLogger(__name__)
 

--- a/src/wily/archivers/git.py
+++ b/src/wily/archivers/git.py
@@ -11,6 +11,7 @@ from git import Commit
 from git.repo import Repo
 
 from wily.archivers import BaseArchiver, Revision
+from wily.config import WilyConfig
 
 logger = logging.getLogger(__name__)
 
@@ -78,7 +79,7 @@ class GitArchiver(BaseArchiver):
 
     name = "git"
 
-    def __init__(self, config):
+    def __init__(self, config: WilyConfig):
         """
         Instantiate a new Git Archiver.
 

--- a/src/wily/archivers/git.py
+++ b/src/wily/archivers/git.py
@@ -102,13 +102,9 @@ class GitArchiver(BaseArchiver):
         Get the list of revisions.
 
         :param path: the path to target.
-        :type  path: ``str``
-
         :param max_revisions: the maximum number of revisions.
-        :type  max_revisions: ``int``
 
         :return: A list of revisions.
-        :rtype: ``list`` of :class:`Revision`
         """
         if self.repo.is_dirty():
             raise DirtyGitRepositoryError(self.repo.untracked_files)
@@ -154,10 +150,7 @@ class GitArchiver(BaseArchiver):
         Checkout a specific revision.
 
         :param revision: The revision identifier.
-        :type  revision: :class:`Revision`
-
         :param options: Any additional options.
-        :type  options: ``dict``
         """
         rev = revision.key
         self.repo.git.checkout(rev)
@@ -176,10 +169,8 @@ class GitArchiver(BaseArchiver):
         Search a string and return a single revision.
 
         :param search: The search term.
-        :type  search: ``str``
 
         :return: An instance of revision.
-        :rtype: Instance of :class:`Revision`
         """
         commit = self.repo.commit(search)
         tracked_files, tracked_dirs = get_tracked_files_dirs(self.repo, commit)

--- a/src/wily/archivers/git.py
+++ b/src/wily/archivers/git.py
@@ -4,7 +4,7 @@ Git Archiver.
 Implementation of the archiver API for the gitpython module.
 """
 import logging
-from typing import Dict, List, Tuple
+from typing import Any, Dict, List, Tuple
 
 import git.exc
 from git import Commit
@@ -25,7 +25,7 @@ class InvalidGitRepositoryError(Exception):
 class DirtyGitRepositoryError(Exception):
     """Error for a dirty git repository (untracked files)."""
 
-    def __init__(self, untracked_files):
+    def __init__(self, untracked_files: List[str]):
         """
         Raise error for untracked files.
 
@@ -114,7 +114,7 @@ class GitArchiver(BaseArchiver):
         if self.repo.is_dirty():
             raise DirtyGitRepositoryError(self.repo.untracked_files)
 
-        revisions = []
+        revisions: List[Revision] = []
         for commit in self.repo.iter_commits(
             self.current_branch, max_count=max_revisions, reverse=True
         ):
@@ -140,7 +140,7 @@ class GitArchiver(BaseArchiver):
                 author_name=commit.author.name,
                 author_email=commit.author.email,
                 date=commit.committed_date,
-                message=commit.message,
+                message=str(commit.message),
                 tracked_files=tracked_files,
                 tracked_dirs=tracked_dirs,
                 added_files=added_files,
@@ -150,7 +150,7 @@ class GitArchiver(BaseArchiver):
             revisions.append(rev)
         return revisions[::-1]
 
-    def checkout(self, revision: Revision, options: Dict):
+    def checkout(self, revision: Revision, options: Dict[Any, Any]) -> None:
         """
         Checkout a specific revision.
 
@@ -198,7 +198,7 @@ class GitArchiver(BaseArchiver):
             author_name=commit.author.name,
             author_email=commit.author.email,
             date=commit.committed_date,
-            message=commit.message,
+            message=str(commit.message),
             tracked_files=tracked_files,
             tracked_dirs=tracked_dirs,
             added_files=added_files,

--- a/src/wily/archivers/git.py
+++ b/src/wily/archivers/git.py
@@ -38,10 +38,16 @@ class DirtyGitRepositoryError(Exception):
 def get_tracked_files_dirs(repo: Repo, commit: Commit) -> Tuple[List[str], List[str]]:
     """Get tracked files in a repo for a commit hash using ls-tree."""
     paths = repo.git.execute(
-        ["git", "ls-tree", "--name-only", "--full-tree", "-r", commit.hexsha]
+        ["git", "ls-tree", "--name-only", "--full-tree", "-r", commit.hexsha],
+        with_extended_output=False,
+        as_process=False,
+        stdout_as_string=True,
     ).split("\n")
     dirs = [""] + repo.git.execute(
-        ["git", "ls-tree", "--name-only", "--full-tree", "-r", "-d", commit.hexsha]
+        ["git", "ls-tree", "--name-only", "--full-tree", "-r", "-d", commit.hexsha],
+        with_extended_output=False,
+        as_process=False,
+        stdout_as_string=True,
     ).split("\n")
     return paths, dirs
 

--- a/src/wily/cache.py
+++ b/src/wily/cache.py
@@ -206,9 +206,9 @@ def get_default_metrics(config: WilyConfig) -> List[str]:
         operators = index[0]["operators"]
         for operator in operators:
             o = resolve_operator(operator)
-            if o.cls.default_metric_index is not None:
-                metric = o.cls.metrics[o.cls.default_metric_index]
-                default_metrics.append(f"{o.cls.name}.{metric.name}")
+            if o.operator_cls.default_metric_index is not None:
+                metric = o.operator_cls.metrics[o.operator_cls.default_metric_index]
+                default_metrics.append(f"{o.operator_cls.name}.{metric.name}")
     return default_metrics
 
 

--- a/src/wily/cache.py
+++ b/src/wily/cache.py
@@ -14,7 +14,7 @@ from typing import Any, Dict, List, Union
 
 from wily import __version__, logger
 from wily.archivers import ALL_ARCHIVERS, Archiver, Revision
-from wily.config import WilyConfig
+from wily.config.types import WilyConfig
 from wily.lang import _
 from wily.operators import resolve_operator
 

--- a/src/wily/cache.py
+++ b/src/wily/cache.py
@@ -19,7 +19,7 @@ from wily.lang import _
 from wily.operators import resolve_operator
 
 
-def exists(config):
+def exists(config: WilyConfig) -> bool:
     """
     Check whether the .wily/ directory exists.
 
@@ -52,7 +52,7 @@ def exists(config):
     return True
 
 
-def create_index(config):
+def create_index(config: WilyConfig) -> None:
     """Create the root index."""
     filename = pathlib.Path(config.cache_path) / "index.json"
     index = {"version": __version__}
@@ -60,15 +60,12 @@ def create_index(config):
         out.write(json.dumps(index, indent=2))
 
 
-def create(config):
+def create(config: WilyConfig) -> str:
     """
     Create a wily cache.
 
     :param config: The configuration
-    :type  config: :class:`wily.config.WilyConfig`
-
     :return: The path to the cache
-    :rtype: ``str``
     """
     if exists(config):
         logger.debug("Wily cache exists, skipping")
@@ -79,7 +76,7 @@ def create(config):
     return config.cache_path
 
 
-def clean(config):
+def clean(config: WilyConfig):
     """
     Delete a wily cache.
 
@@ -171,7 +168,7 @@ def store_archiver_index(
     return filename
 
 
-def list_archivers(config):
+def list_archivers(config: WilyConfig) -> List[str]:
     """
     List the names of archivers with data.
 
@@ -189,15 +186,12 @@ def list_archivers(config):
     return result
 
 
-def get_default_metrics(config):
+def get_default_metrics(config: WilyConfig) -> List[str]:
     """
     Get the default metrics for a configuration.
 
     :param config: The configuration
-    :type  config: :class:`wily.config.WilyConfig`
-
     :return: Return the list of default metrics in this index
-    :rtype: ``list`` of ``str``
     """
     archivers = list_archivers(config)
     default_metrics = []
@@ -218,7 +212,7 @@ def get_default_metrics(config):
     return default_metrics
 
 
-def has_archiver_index(config, archiver):
+def has_archiver_index(config: WilyConfig, archiver: Union[Archiver, str]) -> bool:
     """
     Check if this archiver has an index file.
 
@@ -231,30 +225,29 @@ def has_archiver_index(config, archiver):
     :return: Whether the archiver's index exists.
     :rtype: ``bool``
     """
-    root = pathlib.Path(config.cache_path) / archiver / "index.json"
+    root = pathlib.Path(config.cache_path) / str(archiver) / "index.json"
     return root.exists()
 
 
-def get_archiver_index(config, archiver):
+def get_archiver_index(
+    config: WilyConfig, archiver: Union[Archiver, str]
+) -> Dict[Any, Any]:
     """
     Get the contents of the archiver index file.
 
     :param config: The configuration
-    :type  config: :class:`wily.config.WilyConfig`
-
     :param archiver: The name of the archiver type (e.g. 'git')
-    :type  archiver: ``str``
-
     :return: The index data
-    :rtype: ``dict``
     """
-    root = pathlib.Path(config.cache_path) / archiver
+    root = pathlib.Path(config.cache_path) / str(archiver)
     with (root / "index.json").open("r") as index_f:
         index = json.load(index_f)
     return index
 
 
-def get(config: WilyConfig, archiver: str, revision: str) -> Dict[Any, Any]:
+def get(
+    config: WilyConfig, archiver: Union[Archiver, str], revision: str
+) -> Dict[Any, Any]:
     """
     Get the data for a given revision.
 
@@ -263,7 +256,7 @@ def get(config: WilyConfig, archiver: str, revision: str) -> Dict[Any, Any]:
     :param revision: The revision ID
     :return: The data record for that revision
     """
-    root = pathlib.Path(config.cache_path) / archiver
+    root = pathlib.Path(config.cache_path) / str(archiver)
     # TODO : string escaping!!!
     with (root / f"{revision}.json").open("r") as rev_f:
         index = json.load(rev_f)

--- a/src/wily/cache.py
+++ b/src/wily/cache.py
@@ -10,9 +10,11 @@ import json
 import os.path
 import pathlib
 import shutil
+from typing import Any, Dict, List, Union
 
 from wily import __version__, logger
-from wily.archivers import ALL_ARCHIVERS
+from wily.archivers import ALL_ARCHIVERS, Archiver, Revision
+from wily.config import WilyConfig
 from wily.lang import _
 from wily.operators import resolve_operator
 
@@ -92,28 +94,26 @@ def clean(config):
     logger.debug("Deleted wily cache")
 
 
-def store(config, archiver, revision, stats):
+def store(
+    config: WilyConfig,
+    archiver: Union[Archiver, str],
+    revision: Revision,
+    stats: Dict[str, Any],
+) -> pathlib.Path:
     """
     Store a revision record within an archiver folder.
 
     :param config: The configuration
-    :type  config: :class:`wily.config.WilyConfig`
-
     :param archiver: The archiver to get name from (e.g. 'git')
-    :type  archiver: :class:`Archiver`
-
     :param revision: The revision
-    :type  revision: :class:`Revision` or :class:`LazyRevision`
-
     :param stats: The collected data
-    :type  stats: ``dict``
 
     :return: The absolute path to the created file
     :rtype: ``str``
 
     :rtype: `pathlib.Path`
     """
-    root = pathlib.Path(config.cache_path) / archiver.name
+    root = pathlib.Path(config.cache_path) / str(archiver)
 
     if not root.exists():
         logger.debug("Creating wily cache")
@@ -143,22 +143,20 @@ def store(config, archiver, revision, stats):
     return filename
 
 
-def store_archiver_index(config, archiver, index):
+def store_archiver_index(
+    config: WilyConfig, archiver: Union[Archiver, str], index: List[Dict[str, Any]]
+) -> pathlib.Path:
     """
     Store an archiver's index record for faster search.
 
     :param config: The configuration
-    :type  config: :class:`wily.config.WilyConfig`
-
     :param archiver: The archiver to get name from (e.g. 'git')
-    :type  archiver: :class:`Archiver`
-
     :param index: The archiver index record
     :type  index: ``list``
 
     :rtype: `pathlib.Path`
     """
-    root = pathlib.Path(config.cache_path) / archiver.name
+    root = pathlib.Path(config.cache_path) / str(archiver)
 
     if not root.exists():
         root.mkdir()
@@ -256,21 +254,14 @@ def get_archiver_index(config, archiver):
     return index
 
 
-def get(config, archiver, revision):
+def get(config: WilyConfig, archiver: str, revision: str) -> Dict[Any, Any]:
     """
     Get the data for a given revision.
 
     :param config: The configuration
-    :type  config: :class:`wily.config.WilyConfig`
-
     :param archiver: The archiver to get name from (e.g. 'git')
-    :type  archiver: :class:`Archiver`
-
     :param revision: The revision ID
-    :type  revision: ``str``
-
     :return: The data record for that revision
-    :rtype: ``dict``
     """
     root = pathlib.Path(config.cache_path) / archiver
     # TODO : string escaping!!!

--- a/src/wily/cache.py
+++ b/src/wily/cache.py
@@ -231,7 +231,7 @@ def has_archiver_index(config: WilyConfig, archiver: Union[Archiver, str]) -> bo
 
 def get_archiver_index(
     config: WilyConfig, archiver: Union[Archiver, str]
-) -> Dict[Any, Any]:
+) -> Any:
     """
     Get the contents of the archiver index file.
 

--- a/src/wily/cache.py
+++ b/src/wily/cache.py
@@ -229,9 +229,7 @@ def has_archiver_index(config: WilyConfig, archiver: Union[Archiver, str]) -> bo
     return root.exists()
 
 
-def get_archiver_index(
-    config: WilyConfig, archiver: Union[Archiver, str]
-) -> Any:
+def get_archiver_index(config: WilyConfig, archiver: Union[Archiver, str]) -> Any:
     """
     Get the contents of the archiver index file.
 

--- a/src/wily/cache.py
+++ b/src/wily/cache.py
@@ -24,10 +24,8 @@ def exists(config: WilyConfig) -> bool:
     Check whether the .wily/ directory exists.
 
     :param config: The configuration
-    :type  config: :class:`wily.config.WilyConfig`
 
     :return: Whether the .wily directory exists
-    :rtype: ``boolean``
     """
     exists = (
         pathlib.Path(config.cache_path).exists()
@@ -76,13 +74,11 @@ def create(config: WilyConfig) -> str:
     return config.cache_path
 
 
-def clean(config: WilyConfig):
+def clean(config: WilyConfig) -> None:
     """
     Delete a wily cache.
 
     :param config: The configuration
-    :type  config: :class:`wily.config.WilyConfig`
-
     """
     if not exists(config):
         logger.debug("Wily cache does not exist, skipping")
@@ -106,9 +102,6 @@ def store(
     :param stats: The collected data
 
     :return: The absolute path to the created file
-    :rtype: ``str``
-
-    :rtype: `pathlib.Path`
     """
     root = pathlib.Path(config.cache_path) / str(archiver)
 
@@ -149,9 +142,8 @@ def store_archiver_index(
     :param config: The configuration
     :param archiver: The archiver to get name from (e.g. 'git')
     :param index: The archiver index record
-    :type  index: ``list``
 
-    :rtype: `pathlib.Path`
+    :return: The absolute path to the created file
     """
     root = pathlib.Path(config.cache_path) / str(archiver)
 
@@ -173,10 +165,8 @@ def list_archivers(config: WilyConfig) -> List[str]:
     List the names of archivers with data.
 
     :param config: The configuration
-    :type  config: :class:`wily.config.WilyConfig`
 
     :return: A list of archiver names
-    :rtype: ``list`` of ``str``
     """
     root = pathlib.Path(config.cache_path)
     result = []
@@ -217,13 +207,9 @@ def has_archiver_index(config: WilyConfig, archiver: Union[Archiver, str]) -> bo
     Check if this archiver has an index file.
 
     :param config: The configuration
-    :type  config: :class:`wily.config.WilyConfig`
-
     :param archiver: The name of the archiver type (e.g. 'git')
-    :type  archiver: ``str``
 
     :return: Whether the archiver's index exists.
-    :rtype: ``bool``
     """
     root = pathlib.Path(config.cache_path) / str(archiver) / "index.json"
     return root.exists()

--- a/src/wily/commands/build.py
+++ b/src/wily/commands/build.py
@@ -64,10 +64,8 @@ def build(config: WilyConfig, archiver: Archiver, operators: List[Operator]):
         archiver = FilesystemArchiver(config)
         revisions = archiver.revisions(config.path, config.max_revisions)
     except Exception as e:
-        if hasattr(e, "message"):
-            logger.error(f"Failed to setup archiver: '{e.message}'")
-        else:
-            logger.error(f"Failed to setup archiver: '{type(e)} - {e}'")
+        message = getattr(e, "message", f"{type(e)} - {e}")
+        logger.error(f"Failed to setup archiver: '{message}'")
         exit(1)
 
     state = State(config, archiver=archiver)

--- a/src/wily/commands/build.py
+++ b/src/wily/commands/build.py
@@ -8,34 +8,28 @@ import multiprocessing
 import os
 import pathlib
 from sys import exit
+from typing import Any, Dict, List, Tuple
 
 from progress.bar import Bar
 
 from wily import logger
-from wily.archivers import FilesystemArchiver
+from wily.archivers import Archiver, FilesystemArchiver, Revision
 from wily.archivers.git import InvalidGitRepositoryError
-from wily.operators import resolve_operator
+from wily.config import WilyConfig
+from wily.operators import Operator, resolve_operator
 from wily.state import State
 
 
-def run_operator(operator, revision, config, targets):
+def run_operator(
+    operator: Operator, revision: Revision, config: WilyConfig, targets: List[str]
+) -> Tuple[str, Dict[str, Any]]:
     """
     Run an operator for the multiprocessing pool.
 
     :param operator: The operator to use
-    :type  operator: :class:`Operator`
-
     :param revision: The revision index
-    :type  revision: :class:`Revision`
-
     :param config: The runtime configuration
-    :type  config: :class:`WilyConfig`
-
     :param targets: Files/paths to scan
-    :type  targets: ``list`` of ``str``
-
-    :rtype: ``tuple``
-    :returns: A tuple of operator name (``str``), and data (``dict``)
     """
     instance = operator.cls(config, targets)
     logger.debug(f"Running {operator.name} operator on {revision}")
@@ -52,18 +46,13 @@ def run_operator(operator, revision, config, targets):
     return operator.name, data
 
 
-def build(config, archiver, operators):
+def build(config: WilyConfig, archiver: Archiver, operators: List[Operator]):
     """
     Build the history given an archiver and collection of operators.
 
     :param config: The wily configuration
-    :type  config: :namedtuple:`wily.config.WilyConfig`
-
     :param archiver: The archiver to use
-    :type  archiver: :namedtuple:`wily.archivers.Archiver`
-
     :param operators: The list of operators to execute
-    :type operators: `list` of :namedtuple:`wily.operators.Operator`
     """
     try:
         logger.debug(f"Using {archiver.name} archiver module")

--- a/src/wily/commands/build.py
+++ b/src/wily/commands/build.py
@@ -46,7 +46,7 @@ def run_operator(
     return operator.name, data
 
 
-def build(config: WilyConfig, archiver: Archiver, operators: List[Operator]):
+def build(config: WilyConfig, archiver: Archiver, operators: List[Operator]) -> None:
     """
     Build the history given an archiver and collection of operators.
 

--- a/src/wily/commands/build.py
+++ b/src/wily/commands/build.py
@@ -68,11 +68,11 @@ def build(config: WilyConfig, archiver: Archiver, operators: List[Operator]):
         logger.error(f"Failed to setup archiver: '{message}'")
         exit(1)
 
-    state = State(config, archiver=archiver)
+    state = State(config, archiver=archiver_instance)
     # Check for existence of cache, else provision
     state.ensure_exists()
 
-    index = state.index[archiver.name]
+    index = state.index[archiver_instance.name]
 
     # remove existing revisions from the list
     revisions = [revision for revision in revisions if revision not in index][::-1]
@@ -183,7 +183,7 @@ def build(config: WilyConfig, archiver: Archiver, operators: List[Operator]):
                 prev_stats = stats
                 seed = False
                 ir = index.add(revision, operators=operators)
-                ir.store(config, archiver, stats)
+                ir.store(config, archiver_instance.name, stats)
         index.save()
         bar.finish()
     except Exception as e:

--- a/src/wily/commands/build.py
+++ b/src/wily/commands/build.py
@@ -31,7 +31,7 @@ def run_operator(
     :param config: The runtime configuration
     :param targets: Files/paths to scan
     """
-    instance = operator.cls(config, targets)
+    instance = operator.operator_cls(config, targets)
     logger.debug(f"Running {operator.name} operator on {revision}")
 
     data = instance.run(revision, config)
@@ -56,7 +56,7 @@ def build(config: WilyConfig, archiver: Archiver, operators: List[Operator]):
     """
     try:
         logger.debug(f"Using {archiver.name} archiver module")
-        archiver_instance = archiver.cls(config)
+        archiver_instance = archiver.archiver_cls(config)
         revisions = archiver_instance.revisions(config.path, config.max_revisions)
     except InvalidGitRepositoryError:
         # TODO: This logic shouldn't really be here (SoC)
@@ -165,7 +165,9 @@ def build(config: WilyConfig, archiver: Archiver, operators: List[Operator]):
 
                         result[str(root)] = {"total": {}}
                         # aggregate values
-                        for metric in resolve_operator(operator_name).cls.metrics:
+                        for metric in resolve_operator(
+                            operator_name
+                        ).operator_cls.metrics:
                             func = metric.aggregate
                             values = [
                                 result[aggregate]["total"][metric.name]

--- a/src/wily/commands/build.py
+++ b/src/wily/commands/build.py
@@ -15,7 +15,7 @@ from progress.bar import Bar
 from wily import logger
 from wily.archivers import Archiver, FilesystemArchiver, Revision
 from wily.archivers.git import InvalidGitRepositoryError
-from wily.config import WilyConfig
+from wily.config.types import WilyConfig
 from wily.operators import Operator, resolve_operator
 from wily.state import State
 

--- a/src/wily/commands/diff.py
+++ b/src/wily/commands/diff.py
@@ -37,7 +37,7 @@ def diff(
     detail: bool = True,
     revision: Optional[str] = None,
     wrap: bool = False,
-):
+) -> None:
     """
     Show the differences in metrics for each of the files.
 
@@ -47,6 +47,7 @@ def diff(
     :param changes_only: Only include changes files in output.
     :param detail: Show details (function-level)
     :param revision: Compare with specific revision
+    :param wrap: Wrap output
     """
     config.targets = files
     files = list(files)

--- a/src/wily/commands/diff.py
+++ b/src/wily/commands/diff.py
@@ -136,7 +136,7 @@ def diff(
                 new = "-"
             if new != current:
                 has_changes = True
-            if metric.type in (int, float) and new != "-" and current != "-":
+            if metric.metric_type in (int, float) and new != "-" and current != "-":
                 if current > new:  # type: ignore
                     metrics_data.append(
                         "{0:n} -> \u001b[{2}m{1:n}\u001b[0m".format(

--- a/src/wily/commands/diff.py
+++ b/src/wily/commands/diff.py
@@ -68,7 +68,9 @@ def diff(
     if not revision:
         target_revision = state.index[state.default_archiver].last_revision
     else:
-        rev = resolve_archiver(state.default_archiver).cls(config).find(revision)
+        rev = (
+            resolve_archiver(state.default_archiver).archiver_cls(config).find(revision)
+        )
         logger.debug(f"Resolved {revision} to {rev.key} ({rev.message})")
         try:
             target_revision = state.index[state.default_archiver][rev.key]

--- a/src/wily/commands/diff.py
+++ b/src/wily/commands/diff.py
@@ -134,13 +134,13 @@ def diff(
             if new != current:
                 has_changes = True
             if metric.type in (int, float) and new != "-" and current != "-":
-                if current > new:
+                if current > new: # type: ignore
                     metrics_data.append(
                         "{0:n} -> \u001b[{2}m{1:n}\u001b[0m".format(
                             current, new, BAD_COLORS[metric.measure]
                         )
                     )
-                elif current < new:
+                elif current < new: # type: ignore
                     metrics_data.append(
                         "{0:n} -> \u001b[{2}m{1:n}\u001b[0m".format(
                             current, new, GOOD_COLORS[metric.measure]

--- a/src/wily/commands/diff.py
+++ b/src/wily/commands/diff.py
@@ -134,13 +134,13 @@ def diff(
             if new != current:
                 has_changes = True
             if metric.type in (int, float) and new != "-" and current != "-":
-                if current > new: # type: ignore
+                if current > new:  # type: ignore
                     metrics_data.append(
                         "{0:n} -> \u001b[{2}m{1:n}\u001b[0m".format(
                             current, new, BAD_COLORS[metric.measure]
                         )
                     )
-                elif current < new: # type: ignore
+                elif current < new:  # type: ignore
                     metrics_data.append(
                         "{0:n} -> \u001b[{2}m{1:n}\u001b[0m".format(
                             current, new, GOOD_COLORS[metric.measure]

--- a/src/wily/commands/diff.py
+++ b/src/wily/commands/diff.py
@@ -7,6 +7,7 @@ import multiprocessing
 import os
 from pathlib import Path
 from sys import exit
+from typing import List, Optional
 
 import radon.cli.harvest
 import tabulate
@@ -14,7 +15,7 @@ import tabulate
 from wily import format_date, format_revision, logger
 from wily.archivers import resolve_archiver
 from wily.commands.build import run_operator
-from wily.config import DEFAULT_PATH
+from wily.config import DEFAULT_PATH, WilyConfig
 from wily.helper import get_maxcolwidth, get_style
 from wily.operators import (
     BAD_COLORS,
@@ -28,28 +29,23 @@ from wily.state import State
 
 
 def diff(
-    config, files, metrics, changes_only=True, detail=True, revision=None, wrap=False
+    config: WilyConfig,
+    files: List[str],
+    metrics: List[str],
+    changes_only: bool = True,
+    detail: bool = True,
+    revision: Optional[str] = None,
+    wrap: bool = False,
 ):
     """
     Show the differences in metrics for each of the files.
 
     :param config: The wily configuration
-    :type  config: :namedtuple:`wily.config.WilyConfig`
-
     :param files: The files to compare.
-    :type  files: ``list`` of ``str``
-
     :param metrics: The metrics to measure.
-    :type  metrics: ``list`` of ``str``
-
     :param changes_only: Only include changes files in output.
-    :type  changes_only: ``bool``
-
     :param detail: Show details (function-level)
-    :type  detail: ``bool``
-
     :param revision: Compare with specific revision
-    :type  revision: ``str``
     """
     config.targets = files
     files = list(files)
@@ -87,7 +83,9 @@ def diff(
 
     # Convert the list of metrics to a list of metric instances
     operators = {resolve_operator(metric.split(".")[0]) for metric in metrics}
-    metrics = [(metric.split(".")[0], resolve_metric(metric)) for metric in metrics]
+    resolved_metrics = [
+        (metric.split(".")[0], resolve_metric(metric)) for metric in metrics
+    ]
     results = []
 
     # Build a set of operators
@@ -101,7 +99,7 @@ def diff(
 
     # Write a summary table
     extra = []
-    for operator, metric in metrics:
+    for operator, metric in resolved_metrics:
         if detail and resolve_operator(operator).level == OperatorLevel.Object:
             for file in files:
                 try:
@@ -122,7 +120,7 @@ def diff(
     for file in files:
         metrics_data = []
         has_changes = False
-        for operator, metric in metrics:
+        for operator, metric in resolved_metrics:
             try:
                 current = target_revision.get(
                     config, state.default_archiver, operator, file, metric.name
@@ -160,7 +158,7 @@ def diff(
         else:
             logger.debug(metrics_data)
 
-    descriptions = [metric.description for operator, metric in metrics]
+    descriptions = [metric.description for _, metric in resolved_metrics]
     headers = ("File", *descriptions)
     if len(results) > 0:
         maxcolwidth = get_maxcolwidth(headers, wrap)

--- a/src/wily/commands/diff.py
+++ b/src/wily/commands/diff.py
@@ -15,7 +15,8 @@ import tabulate
 from wily import format_date, format_revision, logger
 from wily.archivers import resolve_archiver
 from wily.commands.build import run_operator
-from wily.config import DEFAULT_PATH, WilyConfig
+from wily.config import DEFAULT_PATH
+from wily.config.types import WilyConfig
 from wily.helper import get_maxcolwidth, get_style
 from wily.operators import (
     BAD_COLORS,

--- a/src/wily/commands/graph.py
+++ b/src/wily/commands/graph.py
@@ -5,11 +5,13 @@ TODO: Add multiple lines for multiple files
 """
 
 from pathlib import Path
+from typing import Optional, Tuple
 
 import plotly.graph_objs as go
 import plotly.offline
 
 from wily import format_datetime, logger
+from wily.config import WilyConfig
 from wily.operators import resolve_metric, resolve_metric_as_tuple
 from wily.state import State
 
@@ -21,41 +23,26 @@ def metric_parts(metric):
 
 
 def graph(
-    config,
-    path,
-    metrics,
-    output=None,
-    x_axis=None,
-    changes=True,
-    text=False,
-    aggregate=False,
+    config: WilyConfig,
+    path: str,
+    metrics: Tuple[str, str],
+    output: Optional[str] = None,
+    x_axis: Optional[str] = None,
+    changes: bool = True,
+    text: bool = False,
+    aggregate: bool = False,
 ):
     """
     Graph information about the cache and runtime.
 
     :param config: The configuration.
-    :type  config: :class:`wily.config.WilyConfig`
-
     :param path: The path to the files.
-    :type  path: ``str``
-
     :param metrics: The Y and Z-axis metrics to report on.
-    :type  metrics: ``tuple``
-
     :param output: Save report to specified path instead of opening browser.
-    :type  output: ``str``
-
     :param x_axis: Name of metric for x-axis or "history".
-    :type x_axis: ``str``
-
     :param changes: Only graph changes.
-    :type changes: ``bool``
-
     :param text: Show commit message inline in graph.
-    :type text: ``bool``
-
     :param aggregate: Aggregate values for graph.
-    :type aggregate: ``bool``
     """
     logger.debug("Running graph command")
 

--- a/src/wily/commands/graph.py
+++ b/src/wily/commands/graph.py
@@ -51,6 +51,7 @@ def graph(
 
     if x_axis is None:
         x_axis = "history"
+        x_operator = x_key = None
     else:
         x_operator, x_key = metric_parts(x_axis)
 
@@ -71,7 +72,7 @@ def graph(
 
     operator, key = metric_parts(metrics[0])
     if len(metrics) == 1:  # only y-axis
-        z_axis = None
+        z_axis = z_operator = z_key = None
     else:
         z_axis = resolve_metric(metrics[1])
         z_operator, z_key = metric_parts(metrics[1])

--- a/src/wily/commands/graph.py
+++ b/src/wily/commands/graph.py
@@ -135,7 +135,7 @@ def graph(
             },
             xcalendar="gregorian",
             hoveron="points+fills",
-        ) # type: ignore
+        )  # type: ignore
         data.append(trace)
     if output:
         filename = output
@@ -150,7 +150,7 @@ def graph(
                 title=title,
                 xaxis={"title": x_axis},
                 yaxis={"title": y_metric.description},
-            ), # type: ignore
+            ),  # type: ignore
         },
         auto_open=auto_open,
         filename=filename,

--- a/src/wily/commands/graph.py
+++ b/src/wily/commands/graph.py
@@ -5,7 +5,7 @@ TODO: Add multiple lines for multiple files
 """
 
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Union
 
 import plotly.graph_objs as go
 import plotly.offline
@@ -25,13 +25,13 @@ def metric_parts(metric):
 def graph(
     config: WilyConfig,
     path: str,
-    metrics: Tuple[str, str],
+    metrics: Union[Tuple[str], Tuple[str, str]],
     output: Optional[str] = None,
     x_axis: Optional[str] = None,
     changes: bool = True,
     text: bool = False,
     aggregate: bool = False,
-):
+) -> None:
     """
     Graph information about the cache and runtime.
 

--- a/src/wily/commands/graph.py
+++ b/src/wily/commands/graph.py
@@ -11,7 +11,7 @@ import plotly.graph_objs as go
 import plotly.offline
 
 from wily import format_datetime, logger
-from wily.config import WilyConfig
+from wily.config.types import WilyConfig
 from wily.operators import resolve_metric, resolve_metric_as_tuple
 from wily.state import State
 

--- a/src/wily/commands/graph.py
+++ b/src/wily/commands/graph.py
@@ -51,7 +51,7 @@ def graph(
 
     if x_axis is None:
         x_axis = "history"
-        x_operator = x_key = None
+        x_operator = x_key = ""
     else:
         x_operator, x_key = metric_parts(x_axis)
 
@@ -72,7 +72,7 @@ def graph(
 
     operator, key = metric_parts(metrics[0])
     if len(metrics) == 1:  # only y-axis
-        z_axis = z_operator = z_key = None
+        z_axis = z_operator = z_key = ""
     else:
         z_axis = resolve_metric(metrics[1])
         z_operator, z_key = metric_parts(metrics[1])
@@ -135,7 +135,7 @@ def graph(
             },
             xcalendar="gregorian",
             hoveron="points+fills",
-        )
+        ) # type: ignore
         data.append(trace)
     if output:
         filename = output
@@ -150,7 +150,7 @@ def graph(
                 title=title,
                 xaxis={"title": x_axis},
                 yaxis={"title": y_metric.description},
-            ),
+            ), # type: ignore
         },
         auto_open=auto_open,
         filename=filename,

--- a/src/wily/commands/index.py
+++ b/src/wily/commands/index.py
@@ -6,7 +6,7 @@ Print information about the wily cache and what is in the index.
 import tabulate
 
 from wily import MAX_MESSAGE_WIDTH, format_date, format_revision, logger
-from wily.config import WilyConfig
+from wily.config.types import WilyConfig
 from wily.helper import get_maxcolwidth, get_style
 from wily.state import State
 

--- a/src/wily/commands/index.py
+++ b/src/wily/commands/index.py
@@ -6,19 +6,18 @@ Print information about the wily cache and what is in the index.
 import tabulate
 
 from wily import MAX_MESSAGE_WIDTH, format_date, format_revision, logger
+from wily.config import WilyConfig
 from wily.helper import get_maxcolwidth, get_style
 from wily.state import State
 
 
-def index(config, include_message=False, wrap=False):
+def index(config: WilyConfig, include_message: bool = False, wrap: bool = False):
     """
     Show information about the cache and runtime.
 
     :param config: The wily configuration
-    :type  config: :namedtuple:`wily.config.WilyConfig`
-
     :param include_message: Include revision messages
-    :type  include_message: ``bool``
+    :param wrap: Wrap long lines
     """
     state = State(config=config)
     logger.debug("Running show command")

--- a/src/wily/commands/index.py
+++ b/src/wily/commands/index.py
@@ -11,7 +11,9 @@ from wily.helper import get_maxcolwidth, get_style
 from wily.state import State
 
 
-def index(config: WilyConfig, include_message: bool = False, wrap: bool = False):
+def index(
+    config: WilyConfig, include_message: bool = False, wrap: bool = False
+) -> None:
     """
     Show information about the cache and runtime.
 

--- a/src/wily/commands/list_metrics.py
+++ b/src/wily/commands/list_metrics.py
@@ -21,7 +21,7 @@ def list_metrics(wrap: bool):
                 tabulate.tabulate(
                     headers=headers,
                     tabular_data=[
-                        (m.name, m.description, m.type, m.measure, m.aggregate)
+                        (m.name, m.description, m.metric_type, m.measure, m.aggregate)
                         for m in operator.operator_cls.metrics
                     ],
                     tablefmt=style,

--- a/src/wily/commands/list_metrics.py
+++ b/src/wily/commands/list_metrics.py
@@ -20,7 +20,10 @@ def list_metrics(wrap: bool):
             print(
                 tabulate.tabulate(
                     headers=headers,
-                    tabular_data=operator.cls.metrics,
+                    tabular_data=[
+                        (m.name, m.description, m.type, m.measure, m.aggregate)
+                        for m in operator.cls.metrics
+                    ],
                     tablefmt=style,
                     maxcolwidths=maxcolwidth,
                     maxheadercolwidths=maxcolwidth,

--- a/src/wily/commands/list_metrics.py
+++ b/src/wily/commands/list_metrics.py
@@ -9,7 +9,7 @@ from wily.helper import get_maxcolwidth, get_style
 from wily.operators import ALL_OPERATORS
 
 
-def list_metrics(wrap):
+def list_metrics(wrap: bool):
     """List metrics available."""
     headers = ("Name", "Description", "Type", "Measure", "Aggregate")
     maxcolwidth = get_maxcolwidth(headers, wrap)

--- a/src/wily/commands/list_metrics.py
+++ b/src/wily/commands/list_metrics.py
@@ -9,7 +9,7 @@ from wily.helper import get_maxcolwidth, get_style
 from wily.operators import ALL_OPERATORS
 
 
-def list_metrics(wrap: bool):
+def list_metrics(wrap: bool) -> None:
     """List metrics available."""
     headers = ("Name", "Description", "Type", "Measure", "Aggregate")
     maxcolwidth = get_maxcolwidth(headers, wrap)

--- a/src/wily/commands/list_metrics.py
+++ b/src/wily/commands/list_metrics.py
@@ -16,13 +16,13 @@ def list_metrics(wrap: bool):
     style = get_style()
     for name, operator in ALL_OPERATORS.items():
         print(f"{name} operator:")
-        if len(operator.cls.metrics) > 0:
+        if len(operator.operator_cls.metrics) > 0:
             print(
                 tabulate.tabulate(
                     headers=headers,
                     tabular_data=[
                         (m.name, m.description, m.type, m.measure, m.aggregate)
-                        for m in operator.cls.metrics
+                        for m in operator.operator_cls.metrics
                     ],
                     tablefmt=style,
                     maxcolwidths=maxcolwidth,

--- a/src/wily/commands/rank.py
+++ b/src/wily/commands/rank.py
@@ -58,7 +58,11 @@ def rank(
     if not revision_index:
         target_revision = state.index[state.default_archiver].last_revision
     else:
-        rev = resolve_archiver(state.default_archiver).cls(config).find(revision_index)
+        rev = (
+            resolve_archiver(state.default_archiver)
+            .archiver_cls(config)
+            .find(revision_index)
+        )
         logger.debug(f"Resolved {revision_index} to {rev.key} ({rev.message})")
         try:
             target_revision = state.index[state.default_archiver][rev.key]

--- a/src/wily/commands/rank.py
+++ b/src/wily/commands/rank.py
@@ -32,7 +32,7 @@ def rank(
     threshold: int,
     descending: bool,
     wrap: bool,
-):
+) -> None:
     """
     Rank command ordering files, methods or functions using metrics.
 
@@ -42,7 +42,8 @@ def rank(
     :param revision_index: Version of git repository to revert to.
     :param limit: Limit the number of items in the table.
     :param threshold: For total values beneath the threshold return a non-zero exit code.
-    :type descending: Rank in descending order
+    :param descending: Rank in descending order
+    :param wrap: Wrap output
 
     :return: Sorted table of all files in path, sorted in order of metric.
     """

--- a/src/wily/commands/rank.py
+++ b/src/wily/commands/rank.py
@@ -17,36 +17,32 @@ import tabulate
 
 from wily import format_date, format_revision, logger
 from wily.archivers import resolve_archiver
-from wily.config import DEFAULT_PATH
+from wily.config import DEFAULT_PATH, WilyConfig
 from wily.helper import get_maxcolwidth, get_style
 from wily.operators import resolve_metric_as_tuple
 from wily.state import State
 
 
-def rank(config, path, metric, revision_index, limit, threshold, descending, wrap):
+def rank(
+    config: WilyConfig,
+    path: str,
+    metric: str,
+    revision_index: str,
+    limit: int,
+    threshold: int,
+    descending: bool,
+    wrap: bool,
+):
     """
     Rank command ordering files, methods or functions using metrics.
 
     :param config: The configuration.
-    :type config: :class:'wily.config.WilyConfig'
-
     :param path: The path to the file.
-    :type path ''str''
-
     :param metric: Name of the metric to report on.
-    :type metric: ''str''
-
     :param revision_index: Version of git repository to revert to.
-    :type revision_index: ``str``
-
     :param limit: Limit the number of items in the table.
-    :type  limit: ``int``
-
     :param threshold: For total values beneath the threshold return a non-zero exit code.
-    :type  threshold: ``int``
-
     :type descending: Rank in descending order
-    :param descending: ``bool``
 
     :return: Sorted table of all files in path, sorted in order of metric.
     """
@@ -54,7 +50,7 @@ def rank(config, path, metric, revision_index, limit, threshold, descending, wra
 
     data = []
 
-    operator, metric = resolve_metric_as_tuple(metric)
+    operator, resolved_metric = resolve_metric_as_tuple(metric)
     operator = operator.name
 
     state = State(config)
@@ -73,7 +69,7 @@ def rank(config, path, metric, revision_index, limit, threshold, descending, wra
             exit(1)
 
     logger.info(
-        f"-----------Rank for {metric.description} for {format_revision(target_revision.revision.key)} by {target_revision.revision.author_name} on {format_date(target_revision.revision.date)}.------------"
+        f"-----------Rank for {resolved_metric.description} for {format_revision(target_revision.revision.key)} by {target_revision.revision.author_name} on {format_date(target_revision.revision.date)}.------------"
     )
 
     if path is None:
@@ -97,10 +93,10 @@ def rank(config, path, metric, revision_index, limit, threshold, descending, wra
         for archiver in state.archivers:
             try:
                 logger.debug(
-                    f"Fetching metric {metric.name} for {operator} in {str(item)}"
+                    f"Fetching metric {resolved_metric.name} for {operator} in {str(item)}"
                 )
                 val = target_revision.get(
-                    config, archiver, operator, str(item), metric.name
+                    config, archiver, operator, str(item), resolved_metric.name
                 )
                 value = val
                 data.append((item, value))
@@ -117,10 +113,10 @@ def rank(config, path, metric, revision_index, limit, threshold, descending, wra
         return
 
     # Tack on the total row at the end
-    total = metric.aggregate(rev[1] for rev in data)
+    total = resolved_metric.aggregate(rev[1] for rev in data)
     data.append(["Total", total])
 
-    headers = ("File", metric.description)
+    headers = ("File", resolved_metric.description)
     maxcolwidth = get_maxcolwidth(headers, wrap)
     style = get_style()
     print(

--- a/src/wily/commands/report.py
+++ b/src/wily/commands/report.py
@@ -58,8 +58,8 @@ def report(
     data = []
     metric_metas = []
 
-    for metric in metrics:
-        operator, metric = resolve_metric_as_tuple(metric)
+    for metric_name in metrics:
+        operator, metric = resolve_metric_as_tuple(metric_name)
         key = metric.name
         operator = operator.name
         # Set the delta colors depending on the metric type

--- a/src/wily/commands/report.py
+++ b/src/wily/commands/report.py
@@ -81,7 +81,7 @@ def report(
             "increase_color": increase_color,
             "decrease_color": decrease_color,
             "title": metric.description,
-            "type": metric.type,
+            "type": metric.metric_type,
         }
         metric_metas.append(metric_meta)
 

--- a/src/wily/commands/report.py
+++ b/src/wily/commands/report.py
@@ -7,12 +7,12 @@ Will compare the values between revisions and highlight changes in green/red.
 from pathlib import Path
 from shutil import copytree
 from string import Template
-from typing import Iterable, Optional
+from typing import Iterable
 
 import tabulate
 
 from wily import MAX_MESSAGE_WIDTH, format_date, format_revision, logger
-from wily.config import WilyConfig
+from wily.config.types import WilyConfig
 from wily.helper import get_maxcolwidth
 from wily.helper.custom_enums import ReportFormat
 from wily.lang import _
@@ -30,9 +30,9 @@ def report(
     metrics: Iterable[str],
     n: int,
     output: Path,
+    console_format: str,
     include_message: bool = False,
     format: ReportFormat = ReportFormat.CONSOLE,
-    console_format: Optional[str] = None,
     changes_only: bool = False,
     wrap: bool = False,
 ):
@@ -205,7 +205,7 @@ def report(
             tabulate.tabulate(
                 headers=headers,
                 tabular_data=data[::-1],
-                tablefmt=console_format if console_format else "simple",
+                tablefmt=console_format,
                 maxcolwidths=maxcolwidth,
                 maxheadercolwidths=maxcolwidth,
             )

--- a/src/wily/commands/report.py
+++ b/src/wily/commands/report.py
@@ -35,7 +35,7 @@ def report(
     format: ReportFormat = ReportFormat.CONSOLE,
     changes_only: bool = False,
     wrap: bool = False,
-):
+) -> None:
     """
     Show metrics for a given file.
 
@@ -50,6 +50,7 @@ def report(
     :param format: Output format
     :param console_format: Grid format style for tabulate
     :param changes_only: Only report revisions where delta != 0
+    :param wrap: Wrap output
     """
     metrics = sorted(metrics)
     logger.debug("Running report command")

--- a/src/wily/commands/report.py
+++ b/src/wily/commands/report.py
@@ -205,7 +205,7 @@ def report(
             tabulate.tabulate(
                 headers=headers,
                 tabular_data=data[::-1],
-                tablefmt=console_format,
+                tablefmt=console_format if console_format else "simple",
                 maxcolwidths=maxcolwidth,
                 maxheadercolwidths=maxcolwidth,
             )

--- a/src/wily/commands/report.py
+++ b/src/wily/commands/report.py
@@ -7,10 +7,12 @@ Will compare the values between revisions and highlight changes in green/red.
 from pathlib import Path
 from shutil import copytree
 from string import Template
+from typing import Collection, Iterable, Optional
 
 import tabulate
 
 from wily import MAX_MESSAGE_WIDTH, format_date, format_revision, logger
+from wily.config import WilyConfig
 from wily.helper import get_maxcolwidth
 from wily.helper.custom_enums import ReportFormat
 from wily.lang import _
@@ -23,16 +25,16 @@ ANSI_YELLOW = 33
 
 
 def report(
-    config,
-    path,
-    metrics,
-    n,
-    output,
-    include_message=False,
-    format=ReportFormat.CONSOLE,
-    console_format=None,
-    changes_only=False,
-    wrap=False,
+    config: WilyConfig,
+    path: str,
+    metrics: Iterable[str],
+    n: int,
+    output: Path,
+    include_message: bool = False,
+    format: ReportFormat = ReportFormat.CONSOLE,
+    console_format: Optional[str] = None,
+    changes_only: bool = False,
+    wrap: bool = False,
 ):
     """
     Show metrics for a given file.
@@ -41,28 +43,13 @@ def report(
     :type  config: :class:`wily.config.WilyConfig`
 
     :param path: The path to the file
-    :type  path: ``str``
-
-    :param metrics: Name of the metric to report on
-    :type  metrics: ``str``
-
+    :param metrics: List of metrics to report on
     :param n: Number of items to list
-    :type  n: ``int``
-
     :param output: Output path
-    :type  output: ``Path``
-
     :param include_message: Include revision messages
-    :type  include_message: ``bool``
-
     :param format: Output format
-    :type  format: ``ReportFormat``
-
     :param console_format: Grid format style for tabulate
-    :type  console_format: ``str``
-
     :param changes_only: Only report revisions where delta != 0
-    :type  changes_only: ``bool``
     """
     metrics = sorted(metrics)
     logger.debug("Running report command")
@@ -203,8 +190,8 @@ def report(
             headers=table_headers, content=table_content
         )
 
-        with report_output.open("w", errors="xmlcharrefreplace") as output:
-            output.write(report_template)
+        with report_output.open("w", errors="xmlcharrefreplace") as output_f:
+            output_f.write(report_template)
 
         try:
             copytree(str(templates_dir / "css"), str(report_path / "css"))

--- a/src/wily/commands/report.py
+++ b/src/wily/commands/report.py
@@ -7,7 +7,7 @@ Will compare the values between revisions and highlight changes in green/red.
 from pathlib import Path
 from shutil import copytree
 from string import Template
-from typing import Collection, Iterable, Optional
+from typing import Iterable, Optional
 
 import tabulate
 

--- a/src/wily/config.py
+++ b/src/wily/config.py
@@ -62,20 +62,20 @@ class WilyConfig:
             self.operators = self._parse_to_list(self.operators)
         if self.targets is None or "":
             self.targets = [self.path]
-        self._cache_path = _cache_path
+        self._cache_path = _cache_path  # type: ignore
 
     @property
     def cache_path(self):
         """Path to the cache."""
-        if not self._cache_path:
-            self._cache_path = generate_cache_path(pathlib.Path(self.path).absolute())
-        return self._cache_path
+        if not self._cache_path:  # type: ignore
+            self._cache_path = generate_cache_path(pathlib.Path(self.path).absolute())  # type: ignore
+        return self._cache_path  # type: ignore
 
     @cache_path.setter
     def cache_path(self, value):
         """Override the cache path."""
         logger.debug(f"Setting custom cache path to {value}")
-        self._cache_path = value
+        self._cache_path = value  # type: ignore
 
     @staticmethod
     def _parse_to_list(string, separator=","):

--- a/src/wily/config.py
+++ b/src/wily/config.py
@@ -11,7 +11,7 @@ import logging
 import pathlib
 from dataclasses import InitVar, dataclass, field
 from functools import lru_cache
-from typing import Any, List
+from typing import Any, Iterable, List, Optional
 
 from wily import operators
 from wily.archivers import ARCHIVER_GIT
@@ -46,13 +46,13 @@ class WilyConfig:
     A data class to reflect the configurable options within Wily.
     """
 
-    operators: List[str]
+    operators: Iterable[str]
     archiver: Any
     path: str
     max_revisions: int
     include_ipynb: bool = True
     ipynb_cells: bool = True
-    targets: List[str] = None
+    targets: Optional[List[str]] = None
     checkout_options: dict = field(default_factory=dict)
     _cache_path: InitVar[str] = ""
 

--- a/src/wily/config/__init__.py
+++ b/src/wily/config/__init__.py
@@ -9,12 +9,11 @@ import configparser
 import hashlib
 import logging
 import pathlib
-from dataclasses import InitVar, dataclass, field
 from functools import lru_cache
-from typing import Any, Iterable, List, Optional
 
 from wily import operators
 from wily.archivers import ARCHIVER_GIT
+from wily.config.types import WilyConfig
 
 logger = logging.getLogger(__name__)
 
@@ -36,55 +35,6 @@ def generate_cache_path(path):
     cache_path = str(HOME / ".wily" / sha)
     logger.debug(f"Cache path is {cache_path}")
     return cache_path
-
-
-@dataclass
-class WilyConfig:
-    """
-    Wily configuration.
-
-    A data class to reflect the configurable options within Wily.
-    """
-
-    operators: Iterable[str]
-    archiver: Any
-    path: str
-    max_revisions: int
-    include_ipynb: bool = True
-    ipynb_cells: bool = True
-    targets: Optional[List[str]] = None
-    checkout_options: dict = field(default_factory=dict)
-    _cache_path: InitVar[str] = ""
-
-    def __post_init__(self, _cache_path):
-        """Parse operators string to list and clone targets as a list of path."""
-        if isinstance(self.operators, str):
-            self.operators = self._parse_to_list(self.operators)
-        if self.targets is None or "":
-            self.targets = [self.path]
-        self._cache_path = _cache_path  # type: ignore
-
-    @property
-    def cache_path(self):
-        """Path to the cache."""
-        if not self._cache_path:  # type: ignore
-            self._cache_path = generate_cache_path(pathlib.Path(self.path).absolute())  # type: ignore
-        return self._cache_path  # type: ignore
-
-    @cache_path.setter
-    def cache_path(self, value):
-        """Override the cache path."""
-        logger.debug(f"Setting custom cache path to {value}")
-        self._cache_path = value  # type: ignore
-
-    @staticmethod
-    def _parse_to_list(string, separator=","):
-        items = []
-        for raw_item in string.split(separator):
-            item = raw_item.strip()
-            if item:
-                items.append(item)
-        return items
 
 
 # Default values for Wily

--- a/src/wily/config/__init__.py
+++ b/src/wily/config/__init__.py
@@ -6,35 +6,20 @@ TODO : Better utilise default values and factory in @dataclass to replace DEFAUL
  and replace the logic in load() to set default values.
 """
 import configparser
-import hashlib
 import logging
 import pathlib
-from functools import lru_cache
 
 from wily import operators
-from wily.archivers import ARCHIVER_GIT
 from wily.config.types import WilyConfig
+from wily.defaults import (
+    DEFAULT_ARCHIVER,
+    DEFAULT_CONFIG_PATH,
+    DEFAULT_CONFIG_SECTION,
+    DEFAULT_MAX_REVISIONS,
+    DEFAULT_PATH,
+)
 
 logger = logging.getLogger(__name__)
-
-
-@lru_cache(maxsize=128)
-def generate_cache_path(path):
-    """
-    Generate a reusable path to cache results.
-
-    Will use the --path of the target and hash into
-    a 9-character directory within the HOME folder.
-
-    :return: The cache path
-    :rtype: ``str``
-    """
-    logger.debug(f"Generating cache for {path}")
-    sha = hashlib.sha1(str(path).encode()).hexdigest()[:9]
-    HOME = pathlib.Path.home()
-    cache_path = str(HOME / ".wily" / sha)
-    logger.debug(f"Cache path is {cache_path}")
-    return cache_path
 
 
 # Default values for Wily
@@ -47,19 +32,6 @@ DEFAULT_OPERATORS = {
     operators.OPERATOR_HALSTEAD.name,
 }
 
-""" The name of the default archiver """
-DEFAULT_ARCHIVER = ARCHIVER_GIT.name
-
-""" The default configuration file name """
-DEFAULT_CONFIG_PATH = "wily.cfg"
-
-""" The default section name in the config """
-DEFAULT_CONFIG_SECTION = "wily"
-
-""" The default maximum number of revisions to archiver """
-DEFAULT_MAX_REVISIONS = 50
-
-DEFAULT_PATH = "."
 
 """ The default configuration for Wily (if no config file exists) """
 DEFAULT_CONFIG = WilyConfig(
@@ -68,9 +40,6 @@ DEFAULT_CONFIG = WilyConfig(
     path=DEFAULT_PATH,
     max_revisions=DEFAULT_MAX_REVISIONS,
 )
-
-""" Default table style in console. See tabulate docs for more. """
-DEFAULT_GRID_STYLE = "fancy_grid"
 
 
 def load(config_path=DEFAULT_CONFIG_PATH):

--- a/src/wily/config/types.py
+++ b/src/wily/config/types.py
@@ -6,6 +6,8 @@ import pathlib
 from dataclasses import InitVar, dataclass, field
 from typing import Any, Iterable, List, Optional
 
+from wily.helper import generate_cache_path
+
 logger = logging.getLogger(__name__)
 
 

--- a/src/wily/config/types.py
+++ b/src/wily/config/types.py
@@ -1,0 +1,58 @@
+"""Define a standard data class for Wily Configuration."""
+
+
+import logging
+import pathlib
+from dataclasses import InitVar, dataclass, field
+from typing import Any, Iterable, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class WilyConfig:
+    """
+    Wily configuration.
+
+    A data class to reflect the configurable options within Wily.
+    """
+
+    operators: Iterable[str]
+    archiver: Any
+    path: str
+    max_revisions: int
+    include_ipynb: bool = True
+    ipynb_cells: bool = True
+    targets: Optional[List[str]] = None
+    checkout_options: dict = field(default_factory=dict)
+    _cache_path: InitVar[str] = ""
+
+    def __post_init__(self, _cache_path):
+        """Parse operators string to list and clone targets as a list of path."""
+        if isinstance(self.operators, str):
+            self.operators = self._parse_to_list(self.operators)
+        if self.targets is None or "":
+            self.targets = [self.path]
+        self._cache_path = _cache_path  # type: ignore
+
+    @property
+    def cache_path(self):
+        """Path to the cache."""
+        if not self._cache_path:  # type: ignore
+            self._cache_path = generate_cache_path(pathlib.Path(self.path).absolute())  # type: ignore
+        return self._cache_path  # type: ignore
+
+    @cache_path.setter
+    def cache_path(self, value):
+        """Override the cache path."""
+        logger.debug(f"Setting custom cache path to {value}")
+        self._cache_path = value  # type: ignore
+
+    @staticmethod
+    def _parse_to_list(string, separator=","):
+        items = []
+        for raw_item in string.split(separator):
+            item = raw_item.strip()
+            if item:
+                items.append(item)
+        return items

--- a/src/wily/decorators.py
+++ b/src/wily/decorators.py
@@ -8,13 +8,13 @@ This API is not intended to be public and should not be consumed directly.
 from wily import __version__
 
 
-def add_version(f):
+def add_version(f: function) -> function:
     """
     Add the version of wily to the help heading.
 
     :param f: function to decorate
     :return: decorated function
     """
-    doc = f.__doc__
+    doc = f.__doc__ if f.__doc__ else ""
     f.__doc__ = "Version: " + __version__ + "\n\n" + doc
     return f

--- a/src/wily/defaults.py
+++ b/src/wily/defaults.py
@@ -1,0 +1,18 @@
+"""Default values."""
+
+""" Default table style in console. See tabulate docs for more. """
+DEFAULT_GRID_STYLE = "fancy_grid"
+
+""" The name of the default archiver """
+DEFAULT_ARCHIVER = "git"
+
+""" The default configuration file name """
+DEFAULT_CONFIG_PATH = "wily.cfg"
+
+""" The default section name in the config """
+DEFAULT_CONFIG_SECTION = "wily"
+
+""" The default maximum number of revisions to archiver """
+DEFAULT_MAX_REVISIONS = 50
+
+DEFAULT_PATH = "."

--- a/src/wily/helper/__init__.py
+++ b/src/wily/helper/__init__.py
@@ -1,11 +1,12 @@
 """Helper package for wily."""
 import shutil
 import sys
+from typing import Sized
 
 from wily.config import DEFAULT_GRID_STYLE
 
 
-def get_maxcolwidth(headers, wrap=True):
+def get_maxcolwidth(headers: Sized, wrap=True):
     """Calculate the maximum column width for a given terminal width."""
     if not wrap:
         return
@@ -21,7 +22,7 @@ def get_maxcolwidth(headers, wrap=True):
     return max(maxcolwidth, 1)
 
 
-def get_style(style=DEFAULT_GRID_STYLE):
+def get_style(style: str = DEFAULT_GRID_STYLE):
     """Select the tablefmt style for tabulate according to what sys.stdout can handle."""
     if style == DEFAULT_GRID_STYLE:
         if sys.stdout.encoding.lower() not in ("utf-8", "utf8"):

--- a/src/wily/helper/__init__.py
+++ b/src/wily/helper/__init__.py
@@ -1,9 +1,15 @@
 """Helper package for wily."""
+import hashlib
+import logging
+import pathlib
 import shutil
 import sys
+from functools import lru_cache
 from typing import Sized
 
-from wily.config import DEFAULT_GRID_STYLE
+from wily.defaults import DEFAULT_GRID_STYLE
+
+logger = logging.getLogger(__name__)
 
 
 def get_maxcolwidth(headers: Sized, wrap=True):
@@ -28,3 +34,22 @@ def get_style(style: str = DEFAULT_GRID_STYLE):
         if sys.stdout.encoding.lower() not in ("utf-8", "utf8"):
             style = "grid"
     return style
+
+
+@lru_cache(maxsize=128)
+def generate_cache_path(path):
+    """
+    Generate a reusable path to cache results.
+
+    Will use the --path of the target and hash into
+    a 9-character directory within the HOME folder.
+
+    :return: The cache path
+    :rtype: ``str``
+    """
+    logger.debug(f"Generating cache for {path}")
+    sha = hashlib.sha1(str(path).encode()).hexdigest()[:9]
+    HOME = pathlib.Path.home()
+    cache_path = str(HOME / ".wily" / sha)
+    logger.debug(f"Cache path is {cache_path}")
+    return cache_path

--- a/src/wily/helper/__init__.py
+++ b/src/wily/helper/__init__.py
@@ -5,14 +5,14 @@ import pathlib
 import shutil
 import sys
 from functools import lru_cache
-from typing import Sized
+from typing import Optional, Sized, Union
 
 from wily.defaults import DEFAULT_GRID_STYLE
 
 logger = logging.getLogger(__name__)
 
 
-def get_maxcolwidth(headers: Sized, wrap=True):
+def get_maxcolwidth(headers: Sized, wrap=True) -> Optional[int]:
     """Calculate the maximum column width for a given terminal width."""
     if not wrap:
         return
@@ -28,7 +28,7 @@ def get_maxcolwidth(headers: Sized, wrap=True):
     return max(maxcolwidth, 1)
 
 
-def get_style(style: str = DEFAULT_GRID_STYLE):
+def get_style(style: str = DEFAULT_GRID_STYLE) -> str:
     """Select the tablefmt style for tabulate according to what sys.stdout can handle."""
     if style == DEFAULT_GRID_STYLE:
         if sys.stdout.encoding.lower() not in ("utf-8", "utf8"):
@@ -37,7 +37,7 @@ def get_style(style: str = DEFAULT_GRID_STYLE):
 
 
 @lru_cache(maxsize=128)
-def generate_cache_path(path):
+def generate_cache_path(path: Union[pathlib.Path, str]) -> str:
     """
     Generate a reusable path to cache results.
 
@@ -45,7 +45,6 @@ def generate_cache_path(path):
     a 9-character directory within the HOME folder.
 
     :return: The cache path
-    :rtype: ``str``
     """
     logger.debug(f"Generating cache for {path}")
     sha = hashlib.sha1(str(path).encode()).hexdigest()[:9]

--- a/src/wily/operators/__init__.py
+++ b/src/wily/operators/__init__.py
@@ -1,9 +1,20 @@
 """Models and types for "operators" the basic measure of a module that measures code."""
 
-from collections import namedtuple
 from enum import Enum
 from functools import lru_cache
-from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Generic,
+    Iterable,
+    List,
+    NamedTuple,
+    Optional,
+    Tuple,
+    TypeVar,
+    Union,
+)
 
 from wily.lang import _
 
@@ -16,7 +27,16 @@ class MetricType(Enum):
     Informational = 3  # Doesn't matter
 
 
-Metric = namedtuple("Metric", "name description type measure aggregate")
+TValue = TypeVar("TValue")
+
+
+class Metric(NamedTuple, Generic[TValue]):
+    name: str
+    description: str
+    type: TValue
+    measure: MetricType
+    aggregate: Callable[[Iterable[TValue]], TValue]
+
 
 GOOD_COLORS = {
     MetricType.AimHigh: 32,
@@ -56,6 +76,9 @@ class BaseOperator:
     """Level at which the operator goes to."""
     level: OperatorLevel = OperatorLevel.File
 
+    def __init__(self, *args, **kwargs):
+        ...
+
     def run(self, module: str, options: Dict[str, Any]) -> Dict[Any, Any]:
         """
         Run the operator.
@@ -78,7 +101,14 @@ from wily.operators.maintainability import MaintainabilityIndexOperator
 from wily.operators.raw import RawMetricsOperator
 
 """Type for an operator."""
-Operator = namedtuple("Operator", "name cls description level")
+
+
+class Operator(NamedTuple):
+    name: str
+    cls: BaseOperator
+    description: str
+    level: OperatorLevel
+
 
 OPERATOR_CYCLOMATIC = Operator(
     name="cyclomatic",

--- a/src/wily/operators/__init__.py
+++ b/src/wily/operators/__init__.py
@@ -28,7 +28,7 @@ class MetricType(Enum):
     Informational = 3  # Doesn't matter
 
 
-TValue = TypeVar("TValue")
+TValue = TypeVar("TValue", str, int, float)
 
 
 class Metric(Generic[TValue]):

--- a/src/wily/operators/__init__.py
+++ b/src/wily/operators/__init__.py
@@ -33,6 +33,8 @@ TValue = TypeVar("TValue")
 
 
 class Metric(NamedTuple, Generic[TValue]):
+    """Represents a metric."""
+
     name: str
     description: str
     type: TValue
@@ -79,6 +81,7 @@ class BaseOperator:
     level: OperatorLevel = OperatorLevel.File
 
     def __init__(self, *args, **kwargs):
+        """Initialise the operator."""
         ...
 
     def run(self, module: str, options: Dict[str, Any]) -> Dict[Any, Any]:
@@ -108,6 +111,8 @@ T = TypeVar("T", bound=Type)
 
 
 class Operator(NamedTuple, Generic[T]):
+    """Operator type."""
+
     name: str
     cls: T
     description: str
@@ -201,9 +206,7 @@ def resolve_metric_as_tuple(metric: str) -> Tuple[Operator, Metric]:
         return r[0]
 
 
-def get_metric(
-    revision: Dict[Any, Any], operator: str, path: str, key: str
-) -> Any:
+def get_metric(revision: Dict[Any, Any], operator: str, path: str, key: str) -> Any:
     """
     Get a metric from the cache.
 

--- a/src/wily/operators/__init__.py
+++ b/src/wily/operators/__init__.py
@@ -167,7 +167,9 @@ def resolve_metric_as_tuple(metric: str) -> Tuple[Operator, Metric]:
         return r[0]
 
 
-def get_metric(revision: Dict[Any, Any], operator: str, path: str, key: str) -> Dict:
+def get_metric(
+    revision: Dict[Any, Any], operator: str, path: str, key: str
+) -> Dict[Any, Any]:
     """
     Get a metric from the cache.
 

--- a/src/wily/operators/__init__.py
+++ b/src/wily/operators/__init__.py
@@ -144,25 +144,19 @@ def resolve_operator(name: str) -> Operator:
 
 
 def resolve_operators(operators: Iterable[Union[Operator, str]]) -> List[Operator]:
-    """
-    Resolve a list of operator names to their corresponding types.
-    """
+    """Resolve a list of operator names to their corresponding types."""
     return [resolve_operator(operator) for operator in iter(operators)]
 
 
 @lru_cache(maxsize=128)
 def resolve_metric(metric: str) -> Metric:
-    """
-    Resolve metric key to a given target.
-    """
+    """Resolve metric key to a given target."""
     return resolve_metric_as_tuple(metric)[1]
 
 
 @lru_cache(maxsize=128)
 def resolve_metric_as_tuple(metric: str) -> Tuple[Operator, Metric]:
-    """
-    Resolve metric key to a given target.
-    """
+    """Resolve metric key to a given target."""
     if "." in metric:
         _, metric = metric.split(".")
 

--- a/src/wily/operators/__init__.py
+++ b/src/wily/operators/__init__.py
@@ -133,7 +133,11 @@ class Operator(Generic[T]):
     level: OperatorLevel
 
     def __init__(
-        self, name: str, cls: Type[T], description: str, level: OperatorLevel = OperatorLevel.File
+        self,
+        name: str,
+        cls: Type[T],
+        description: str,
+        level: OperatorLevel = OperatorLevel.File,
     ):
         """Initialise the operator."""
         self.name = name

--- a/src/wily/operators/__init__.py
+++ b/src/wily/operators/__init__.py
@@ -9,7 +9,6 @@ from typing import (
     Generic,
     Iterable,
     List,
-    NamedTuple,
     Optional,
     Set,
     Tuple,

--- a/src/wily/operators/__init__.py
+++ b/src/wily/operators/__init__.py
@@ -17,6 +17,7 @@ from typing import (
     Union,
 )
 
+from wily.config.types import WilyConfig
 from wily.lang import _
 
 

--- a/src/wily/operators/__init__.py
+++ b/src/wily/operators/__init__.py
@@ -37,7 +37,7 @@ class Metric(Generic[TValue]):
 
     name: str
     description: str
-    type: TValue
+    metric_type: TValue
     measure: MetricType
     aggregate: Callable[[Iterable[TValue]], TValue]
 
@@ -45,14 +45,14 @@ class Metric(Generic[TValue]):
         self,
         name: str,
         description: str,
-        type: TValue,
+        metric_type: TValue,
         measure: MetricType,
         aggregate: Callable[[Iterable[TValue]], TValue],
     ):
         """Initialise the metric."""
         self.name = name
         self.description = description
-        self.type = type
+        self.metric_type = metric_type
         self.measure = measure
         self.aggregate = aggregate
 
@@ -129,52 +129,52 @@ class Operator(Generic[T]):
     """Operator holder."""
 
     name: str
-    cls: Type[T]
+    operator_cls: Type[T]
     description: str
     level: OperatorLevel
 
     def __init__(
         self,
         name: str,
-        cls: Type[T],
+        operator_cls: Type[T],
         description: str,
         level: OperatorLevel = OperatorLevel.File,
     ):
         """Initialise the operator."""
         self.name = name
-        self.cls = cls
+        self.operator_cls = operator_cls
         self.description = description
         self.level = level
 
     def __call__(self, config: "WilyConfig") -> T:
         """Initialise the operator."""
-        return self.cls(config)
+        return self.operator_cls(config)
 
 
 OPERATOR_CYCLOMATIC = Operator(
     name="cyclomatic",
-    cls=CyclomaticComplexityOperator,
+    operator_cls=CyclomaticComplexityOperator,
     description=_("Cyclomatic Complexity of modules"),
     level=OperatorLevel.Object,
 )
 
 OPERATOR_RAW = Operator(
     name="raw",
-    cls=RawMetricsOperator,
+    operator_cls=RawMetricsOperator,
     description=_("Raw Python statistics"),
     level=OperatorLevel.File,
 )
 
 OPERATOR_MAINTAINABILITY = Operator(
     name="maintainability",
-    cls=MaintainabilityIndexOperator,
+    operator_cls=MaintainabilityIndexOperator,
     description=_("Maintainability index (lines of code and branching)"),
     level=OperatorLevel.File,
 )
 
 OPERATOR_HALSTEAD = Operator(
     name="halstead",
-    cls=HalsteadOperator,
+    operator_cls=HalsteadOperator,
     description=_("Halstead metrics"),
     level=OperatorLevel.Object,
 )
@@ -196,7 +196,7 @@ ALL_OPERATORS: Dict[str, Operator] = {
 ALL_METRICS: Set[Tuple[Operator, Metric[Any]]] = {
     (operator, metric)
     for operator in ALL_OPERATORS.values()
-    for metric in operator.cls.metrics
+    for metric in operator.operator_cls.metrics
 }
 
 

--- a/src/wily/operators/__init__.py
+++ b/src/wily/operators/__init__.py
@@ -11,7 +11,9 @@ from typing import (
     List,
     NamedTuple,
     Optional,
+    Set,
     Tuple,
+    Type,
     TypeVar,
     Union,
 )
@@ -102,10 +104,12 @@ from wily.operators.raw import RawMetricsOperator
 
 """Type for an operator."""
 
+T = TypeVar("T", bound=Type)
 
-class Operator(NamedTuple):
+
+class Operator(NamedTuple, Generic[T]):
     name: str
-    cls: BaseOperator
+    cls: T
     description: str
     level: OperatorLevel
 
@@ -140,7 +144,7 @@ OPERATOR_HALSTEAD = Operator(
 
 
 """Dictionary of all operators"""
-ALL_OPERATORS = {
+ALL_OPERATORS: Dict[str, Operator] = {
     operator.name: operator
     for operator in (
         OPERATOR_CYCLOMATIC,
@@ -152,7 +156,7 @@ ALL_OPERATORS = {
 
 
 """Set of all metrics"""
-ALL_METRICS = {
+ALL_METRICS: Set[Tuple[Operator, Metric[Any]]] = {
     (operator, metric)
     for operator in ALL_OPERATORS.values()
     for metric in operator.cls.metrics
@@ -199,7 +203,7 @@ def resolve_metric_as_tuple(metric: str) -> Tuple[Operator, Metric]:
 
 def get_metric(
     revision: Dict[Any, Any], operator: str, path: str, key: str
-) -> Dict[Any, Any]:
+) -> Any:
     """
     Get a metric from the cache.
 

--- a/src/wily/operators/__init__.py
+++ b/src/wily/operators/__init__.py
@@ -3,7 +3,7 @@
 from collections import namedtuple
 from enum import Enum
 from functools import lru_cache
-from typing import Any, Dict, Iterable, List, Union
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
 from wily.lang import _
 
@@ -42,19 +42,19 @@ class BaseOperator:
     """Abstract Operator Class."""
 
     """Name of the operator."""
-    name = "abstract"
+    name: str = "abstract"
 
     """Default settings."""
-    defaults = {}
+    defaults: Dict[str, Any] = {}
 
     """Available metrics as a list of tuple ("name"<str>, "description"<str>, "type"<type>, "metric_type"<MetricType>)."""
-    metrics = ()
+    metrics: Tuple[Metric, ...] = ()
 
     """Which metric is the default to display in the report command."""
-    default_metric_index = None
+    default_metric_index: Optional[int] = None
 
     """Level at which the operator goes to."""
-    level = OperatorLevel.File
+    level: OperatorLevel = OperatorLevel.File
 
     def run(self, module: str, options: Dict[str, Any]) -> Dict[Any, Any]:
         """
@@ -146,11 +146,6 @@ def resolve_operator(name: str) -> Operator:
 def resolve_operators(operators: Iterable[Union[Operator, str]]) -> List[Operator]:
     """
     Resolve a list of operator names to their corresponding types.
-
-    :param operators: The list of operators
-    :type  operators: iterable or ``str``
-
-    :rtype: ``list`` of :class:`Operator`
     """
     return [resolve_operator(operator) for operator in iter(operators)]
 
@@ -159,24 +154,14 @@ def resolve_operators(operators: Iterable[Union[Operator, str]]) -> List[Operato
 def resolve_metric(metric: str) -> Metric:
     """
     Resolve metric key to a given target.
-
-    :param metric: the metric name.
-    :type  metric: ``str``
-
-    :rtype: :class:`Metric`
     """
     return resolve_metric_as_tuple(metric)[1]
 
 
 @lru_cache(maxsize=128)
-def resolve_metric_as_tuple(metric):
+def resolve_metric_as_tuple(metric: str) -> Tuple[Operator, Metric]:
     """
     Resolve metric key to a given target.
-
-    :param metric: the metric name.
-    :type  metric: ``str``
-
-    :rtype: tuple(:class:`Operator`, :class:`Metric`)
     """
     if "." in metric:
         _, metric = metric.split(".")
@@ -188,24 +173,16 @@ def resolve_metric_as_tuple(metric):
         return r[0]
 
 
-def get_metric(revision, operator, path, key):
+def get_metric(revision: Dict[Any, Any], operator: str, path: str, key: str) -> Dict:
     """
     Get a metric from the cache.
 
     :param revision: The revision data.
-    :type  revision: ``dict``
-
     :param operator: The operator name.
-    :type  operator: ``str``
-
     :param path: The path to the file/function
-    :type  path: ``str``
-
     :param key: The key of the data
-    :type  key: ``str``
 
     :return: Data from the cache
-    :rtype: ``dict``
     """
     if ":" in path:
         part, entry = path.split(":")

--- a/src/wily/operators/cyclomatic.py
+++ b/src/wily/operators/cyclomatic.py
@@ -8,6 +8,7 @@ import statistics
 import radon
 import radon.cli.harvest as harvesters
 from radon.cli import Config
+from radon.complexity import SCORE
 from radon.visitors import Class, Function
 
 from wily import logger
@@ -26,7 +27,7 @@ class CyclomaticComplexityOperator(BaseOperator):
         "max": "F",
         "no_assert": True,
         "show_closures": False,
-        "order": radon.complexity.SCORE,
+        "order": SCORE,
         "include_ipynb": True,
         "ipynb_cells": True,
     }

--- a/src/wily/operators/cyclomatic.py
+++ b/src/wily/operators/cyclomatic.py
@@ -5,7 +5,6 @@ Provided by the radon library.
 """
 import statistics
 
-import radon
 import radon.cli.harvest as harvesters
 from radon.cli import Config
 from radon.complexity import SCORE

--- a/src/wily/operators/raw.py
+++ b/src/wily/operators/raw.py
@@ -7,6 +7,7 @@ import radon.cli.harvest as harvesters
 from radon.cli import Config
 
 from wily import logger
+from wily.lang import _
 from wily.operators import BaseOperator, Metric, MetricType
 
 

--- a/src/wily/state.py
+++ b/src/wily/state.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, List, Optional, Union
 
 from wily import cache, logger
 from wily.archivers import Archiver, Revision, resolve_archiver
-from wily.config import WilyConfig
+from wily.config.types import WilyConfig
 from wily.operators import Operator, get_metric
 
 

--- a/src/wily/state.py
+++ b/src/wily/state.py
@@ -8,7 +8,7 @@ from dataclasses import asdict, dataclass
 from typing import Any, Dict, List, Optional, Union
 
 from wily import cache, logger
-from wily.archivers import Archiver, Revision, resolve_archiver
+from wily.archivers import Archiver, BaseArchiver, Revision, resolve_archiver
 from wily.config.types import WilyConfig
 from wily.operators import Operator, get_metric
 
@@ -81,7 +81,9 @@ class IndexedRevision:
         logger.debug("Fetching keys")
         return list(self._data[operator].keys())
 
-    def store(self, config: WilyConfig, archiver: Archiver, stats: Dict[str, Any]):
+    def store(
+        self, config: WilyConfig, archiver: Union[Archiver, str], stats: Dict[str, Any]
+    ):
         """
         Store the stats for this indexed revision.
 
@@ -185,15 +187,16 @@ class State:
     default_archiver: str
     operators: Optional[List[Operator]] = None
 
-    def __init__(self, config: WilyConfig, archiver: Optional[Archiver] = None):
+    def __init__(
+        self,
+        config: WilyConfig,
+        archiver: Optional[Union[Archiver, BaseArchiver]] = None,
+    ):
         """
         Instantiate a new process state.
 
         :param config: The wily configuration.
-        :type  config: :class:`WilyConfig`
-
         :param archiver: The archiver (optional).
-        :type  archiver: :class:`wily.archivers.Archiver`
         """
         if archiver:
             self.archivers = [archiver.name]

--- a/src/wily/state.py
+++ b/src/wily/state.py
@@ -5,11 +5,12 @@ Contains a lazy revision, index and process state model.
 """
 from collections import OrderedDict
 from dataclasses import asdict, dataclass
-from typing import List
+from typing import Any, Dict, List, Optional, Union
 
 from wily import cache, logger
-from wily.archivers import Revision, resolve_archiver
-from wily.operators import get_metric
+from wily.archivers import Archiver, Revision, resolve_archiver
+from wily.config import WilyConfig
+from wily.operators import Operator, get_metric
 
 
 @dataclass
@@ -21,7 +22,7 @@ class IndexedRevision:
     _data = None
 
     @staticmethod
-    def fromdict(d):
+    def fromdict(d: Dict[str, Any]) -> "IndexedRevision":
         """Instantiate from a dictionary."""
         rev = Revision(
             key=d["key"],
@@ -38,30 +39,23 @@ class IndexedRevision:
         operators = d["operators"]
         return IndexedRevision(revision=rev, operators=operators)
 
-    def asdict(self):
+    def asdict(self) -> Dict[str, Any]:
         """Convert to dictionary."""
         d = asdict(self.revision)
         d["operators"] = self.operators
         return d
 
-    def get(self, config, archiver, operator, path, key):
+    def get(
+        self, config: WilyConfig, archiver: Archiver, operator: str, path: str, key: str
+    ) -> Dict[Any, Any]:
         """
         Get the metric data for this indexed revision.
 
         :param config: The wily config.
-        :type  config: :class:`wily.config.WilyConfig`
-
         :param archiver: The archiver.
-        :type  archiver: :class:`wily.archivers.Archiver`
-
         :param operator: The operator to find
-        :type  operator: ``str``
-
         :param path: The path to find
-        :type  path: ``str``
-
         :param key: The metric key
-        :type  key: ``str``
         """
         if not self._data:
             self._data = cache.get(
@@ -70,18 +64,17 @@ class IndexedRevision:
         logger.debug(f"Fetching metric {path} - {key} for operator {operator}")
         return get_metric(self._data, operator, path, key)
 
-    def get_paths(self, config, archiver, operator):
+    def get_paths(
+        self, config: WilyConfig, archiver: Archiver, operator: str
+    ) -> List[str]:
         """
         Get the indexed paths for this indexed revision.
 
         :param config: The wily config.
-        :type  config: :class:`wily.config.WilyConfig`
-
         :param archiver: The archiver.
-        :type  archiver: :class:`wily.archivers.Archiver`
-
         :param operator: The operator to find
-        :type  operator: ``str``
+
+        :return: A list of paths
         """
         if not self._data:
             self._data = cache.get(
@@ -90,18 +83,13 @@ class IndexedRevision:
         logger.debug("Fetching keys")
         return list(self._data[operator].keys())
 
-    def store(self, config, archiver, stats):
+    def store(self, config: WilyConfig, archiver: Archiver, stats: Dict[str, Any]):
         """
         Store the stats for this indexed revision.
 
         :param config: The wily config.
-        :type  config: :class:`wily.config.WilyConfig`
-
         :param archiver: The archiver.
-        :type  archiver: :class:`wily.archivers.Archiver`
-
         :param stats: The data
-        :type  stats: ``dict``
         """
         self._data = stats
         return cache.store(config, archiver, self.revision, stats)
@@ -110,17 +98,17 @@ class IndexedRevision:
 class Index:
     """The index of the wily cache."""
 
+    archiver: Archiver
+    config: WilyConfig
     operators = None
+    data: List[Any]
 
-    def __init__(self, config, archiver):
+    def __init__(self, config: WilyConfig, archiver: Archiver):
         """
         Instantiate a new index.
 
         :param config: The wily config.
-        :type  config: :class:`wily.config.WilyConfig`
-
         :param archiver: The archiver.
-        :type  archiver: :class:`wily.archivers.Archiver`
         """
         self.config = config
         self.archiver = archiver
@@ -139,41 +127,22 @@ class Index:
         return len(self._revisions)
 
     @property
-    def last_revision(self):
-        """
-        Return the most recent revision.
-
-        :rtype: Instance of :class:`IndexedRevision`
-        """
+    def last_revision(self) -> IndexedRevision:
+        """Return the most recent revision."""
         return next(iter(self._revisions.values()))
 
     @property
-    def revisions(self):
-        """
-        List of all the revisions.
-
-        :rtype: ``list`` of :class:`LazyRevision`
-        """
+    def revisions(self) -> List[IndexedRevision]:
+        """List of all the revisions."""
         return list(self._revisions.values())
 
     @property
-    def revision_keys(self):
-        """
-        List of all the revision indexes.
-
-        :rtype: ``list`` of ``str``
-        """
+    def revision_keys(self) -> List[str]:
+        """List of all the revision indexes."""
         return list(self._revisions.keys())
 
-    def __contains__(self, item):
-        """
-        Check if index contains `item`.
-
-        :param item: The item to search for
-        :type  item: ``str``, :class:`Revision` or :class:`LazyRevision`
-
-        :return: ``True`` for contains, ``False`` for not.
-        """
+    def __contains__(self, item: Union[str, Revision]) -> bool:
+        """Check if index contains `item`."""
         if isinstance(item, Revision):
             return item.key in self._revisions
         elif isinstance(item, str):
@@ -181,20 +150,16 @@ class Index:
         else:
             raise TypeError("Invalid type for __contains__ in Index.")
 
-    def __getitem__(self, index):
+    def __getitem__(self, index) -> IndexedRevision:
         """Get the revision for a specific index."""
         return self._revisions[index]
 
-    def add(self, revision, operators):
+    def add(self, revision: Revision, operators: List[Operator]) -> IndexedRevision:
         """
         Add a revision to the index.
 
         :param revision: The revision.
-        :type  revision: :class:`Revision` or :class:`LazyRevision`
-
         :param operators: Operators for the revision.
-        :type operators:  ``list`` of :class:`Operator`
-
         """
         ir = IndexedRevision(
             revision=revision, operators=[operator.name for operator in operators]
@@ -216,7 +181,12 @@ class State:
     Includes indexes for each archiver.
     """
 
-    def __init__(self, config, archiver=None):
+    archivers: List[str]
+    config: WilyConfig
+    index: Dict[str, Index]
+    default_archiver: str
+
+    def __init__(self, config: WilyConfig, archiver: Optional[Archiver] = None):
         """
         Instantiate a new process state.
 
@@ -233,8 +203,8 @@ class State:
         logger.debug(f"Initialised state indexes for archivers {self.archivers}")
         self.config = config
         self.index = {}
-        for archiver in self.archivers:
-            self.index[archiver] = Index(self.config, resolve_archiver(archiver))
+        for _archiver in self.archivers:
+            self.index[_archiver] = Index(self.config, resolve_archiver(_archiver))
         self.default_archiver = self.archivers[0]
 
     def ensure_exists(self):

--- a/src/wily/state.py
+++ b/src/wily/state.py
@@ -46,7 +46,7 @@ class IndexedRevision:
         return d
 
     def get(
-        self, config: WilyConfig, archiver: Archiver, operator: str, path: str, key: str
+        self, config: WilyConfig, archiver: str, operator: str, path: str, key: str
     ) -> Dict[Any, Any]:
         """
         Get the metric data for this indexed revision.
@@ -64,9 +64,7 @@ class IndexedRevision:
         logger.debug(f"Fetching metric {path} - {key} for operator {operator}")
         return get_metric(self._data, operator, path, key)
 
-    def get_paths(
-        self, config: WilyConfig, archiver: Archiver, operator: str
-    ) -> List[str]:
+    def get_paths(self, config: WilyConfig, archiver: str, operator: str) -> List[str]:
         """
         Get the indexed paths for this indexed revision.
 

--- a/src/wily/state.py
+++ b/src/wily/state.py
@@ -5,6 +5,7 @@ Contains a lazy revision, index and process state model.
 """
 from collections import OrderedDict
 from dataclasses import asdict, dataclass
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
 from wily import cache, logger
@@ -83,7 +84,7 @@ class IndexedRevision:
 
     def store(
         self, config: WilyConfig, archiver: Union[Archiver, str], stats: Dict[str, Any]
-    ):
+    ) -> Path:
         """
         Store the stats for this indexed revision.
 

--- a/src/wily/state.py
+++ b/src/wily/state.py
@@ -47,7 +47,7 @@ class IndexedRevision:
 
     def get(
         self, config: WilyConfig, archiver: str, operator: str, path: str, key: str
-    ) -> Dict[Any, Any]:
+    ) -> Any:
         """
         Get the metric data for this indexed revision.
 
@@ -183,6 +183,7 @@ class State:
     config: WilyConfig
     index: Dict[str, Index]
     default_archiver: str
+    operators: Optional[List[Operator]] = None
 
     def __init__(self, config: WilyConfig, archiver: Optional[Archiver] = None):
         """

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,5 +1,4 @@
 import pathlib
-import shutil
 import tempfile
 from textwrap import dedent
 
@@ -277,4 +276,4 @@ def cache_path(monkeypatch):
     tmp = tempfile.mkdtemp()
     monkeypatch.setenv("HOME", tmp)
     yield tmp
-    shutil.rmtree(tmp)
+    # shutil.rmtree(tmp)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,4 +1,5 @@
 import pathlib
+import shutil
 import tempfile
 from textwrap import dedent
 
@@ -276,4 +277,4 @@ def cache_path(monkeypatch):
     tmp = tempfile.mkdtemp()
     monkeypatch.setenv("HOME", tmp)
     yield tmp
-    # shutil.rmtree(tmp)
+    shutil.rmtree(tmp)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -5,7 +5,8 @@ from textwrap import dedent
 
 import pytest
 from click.testing import CliRunner
-from git import Actor, Repo
+from git.repo.base import Repo
+from git.util import Actor
 
 import wily.__main__ as main
 

--- a/test/integration/test_all_operators.py
+++ b/test/integration/test_all_operators.py
@@ -9,7 +9,8 @@ from textwrap import dedent
 
 import pytest
 from click.testing import CliRunner
-from git import Actor, Repo
+from git.repo.base import Repo
+from git.util import Actor
 
 import wily.__main__ as main
 

--- a/test/integration/test_archiver.py
+++ b/test/integration/test_archiver.py
@@ -1,7 +1,8 @@
 import pathlib
 
 import pytest
-from git import Actor, Repo
+from git.repo.base import Repo
+from git.util import Actor
 
 from wily.archivers.git import DirtyGitRepositoryError, GitArchiver
 from wily.config import DEFAULT_CONFIG

--- a/test/integration/test_build.py
+++ b/test/integration/test_build.py
@@ -12,11 +12,12 @@ from unittest.mock import patch
 
 import pytest
 from click.testing import CliRunner
-from git import Actor, Repo
+from git.repo.base import Repo
+from git.util import Actor
 
 import wily.__main__ as main
 from wily.archivers import ALL_ARCHIVERS
-from wily.config import generate_cache_path
+from wily.helper import generate_cache_path
 
 _path = "src\\test.py" if sys.platform == "win32" else "src/test.py"
 

--- a/test/integration/test_complex_commits.py
+++ b/test/integration/test_complex_commits.py
@@ -8,7 +8,8 @@ import sys
 
 import pytest
 from click.testing import CliRunner
-from git import Actor, Repo
+from git.repo.base import Repo
+from git.util import Actor
 
 import wily.__main__ as main
 

--- a/test/integration/test_rank.py
+++ b/test/integration/test_rank.py
@@ -1,5 +1,6 @@
 from click.testing import CliRunner
-from git import Actor, Repo
+from git.repo.base import Repo
+from git.util import Actor
 
 import wily.__main__ as main
 

--- a/test/unit/test_archivers.py
+++ b/test/unit/test_archivers.py
@@ -5,7 +5,7 @@ import pytest
 
 import wily.archivers
 import wily.config
-from wily.archivers import Revision, git
+from wily.archivers import git
 
 
 class MockAuthor:

--- a/test/unit/test_archivers.py
+++ b/test/unit/test_archivers.py
@@ -5,7 +5,7 @@ import pytest
 
 import wily.archivers
 import wily.config
-from wily.archivers import git
+from wily.archivers import Revision, git
 
 
 class MockAuthor:
@@ -76,12 +76,7 @@ def repo(tmpdir):
 
 
 def test_basearchiver():
-    archiver = wily.archivers.BaseArchiver()
-    with pytest.raises(NotImplementedError):
-        archiver.revisions("", 10)
-
-    with pytest.raises(NotImplementedError):
-        archiver.checkout("")
+    wily.archivers.BaseArchiver(None)
 
 
 def test_defaults():

--- a/test/unit/test_archivers.py
+++ b/test/unit/test_archivers.py
@@ -58,7 +58,7 @@ class MockGit:
     def checkout(self, *args):
         ...
 
-    def execute(self, command):
+    def execute(self, command, *args, **kwargs):
         if command[1] == "ls-tree":
             assert command[-1] == "123abc"
             return "\n"

--- a/test/unit/test_cache.py
+++ b/test/unit/test_cache.py
@@ -5,8 +5,8 @@ import sys
 import pytest
 
 from wily import cache
-from wily.archivers import Revision
-from wily.config import ARCHIVER_GIT, DEFAULT_CONFIG
+from wily.archivers import ARCHIVER_GIT, Revision
+from wily.config import DEFAULT_CONFIG
 
 
 def test_exists(tmpdir):

--- a/test/unit/test_helper.py
+++ b/test/unit/test_helper.py
@@ -3,7 +3,7 @@ from unittest import mock
 
 import tabulate
 
-from wily.config import DEFAULT_GRID_STYLE
+from wily.defaults import DEFAULT_GRID_STYLE
 from wily.helper import get_maxcolwidth, get_style
 
 SHORT_DATA = [list("abcdefgh"), list("abcdefgh")]


### PR DESCRIPTION
Changes: 

- `Operator` `Metric` and `Archiver` are now generics
- Uses pyright to check 
- Pins tabulate and gitpython versions that require specific flags we're using
- Removes docstring types

there are possible more places to add types and some violations reported by MyPy, but this is a good start