### PR TITLE
Fix ruff error due to use of .format() in diff.py

### DIFF
--- a/src/wily/commands/diff.py
+++ b/src/wily/commands/diff.py
@@ -140,15 +140,11 @@ def diff(
             if metric.metric_type in (int, float) and new != "-" and current != "-":
                 if current > new:  # type: ignore
                     metrics_data.append(
-                        "{0:n} -> \u001b[{2}m{1:n}\u001b[0m".format(
-                            current, new, BAD_COLORS[metric.measure]
-                        )
+                        f"{current:n} -> \u001b[{BAD_COLORS[metric.measure]}m{new:n}\u001b[0m"
                     )
                 elif current < new:  # type: ignore
                     metrics_data.append(
-                        "{0:n} -> \u001b[{2}m{1:n}\u001b[0m".format(
-                            current, new, GOOD_COLORS[metric.measure]
-                        )
+                        f"{current:n} -> \u001b[{GOOD_COLORS[metric.measure]}m{new:n}\u001b[0m"
                     )
                 else:
                     metrics_data.append(f"{current:n} -> {new:n}")


### PR DESCRIPTION
Newer versions of ruff started flagging an error in `src/wily/commands/diff.py`. This PR is the result of merely calling ruff with the `--fix` option:
```
src\wily\commands\diff.py:143:25: UP032 [*] Use f-string instead of `format` call
141 |                   if current > new:  # type: ignore
142 |                       metrics_data.append(
143 |                           "{0:n} -> \u001b[{2}m{1:n}\u001b[0m".format(
    |  _________________________^
144 | |                             current, new, BAD_COLORS[metric.measure]
145 | |                         )
    | |_________________________^ UP032
146 |                       )
147 |                   elif current < new:  # type: ignore
    |
    = help: Convert to f-string
src\wily\commands\diff.py:149:25: UP032 [*] Use f-string instead of `format` call
    |
148 |                       metrics_data.append(
149 |                           "{0:n} -> \u001b[{2}m{1:n}\u001b[0m".format(
    |  _________________________^
150 | |                             current, new, GOOD_COLORS[metric.measure]
151 | |                         )
    | |_________________________^ UP032
152 |                       )
153 |                   else:
    |
    = help: Convert to f-string

Found 2 errors.
[*] 2 potentially fixable with the --fix option.
```

This currently blocks #206.