### PR TITLE
Experiment: Convert .gitignore entries to radon ignore/exlude

### DIFF
--- a/src/wily/commands/build.py
+++ b/src/wily/commands/build.py
@@ -1,8 +1,7 @@
 """
+Build command.
+
 Builds a cache based on a source-control history.
-
-TODO : Convert .gitignore to radon ignore patterns to make the build more efficient.
-
 """
 import multiprocessing
 import os
@@ -22,7 +21,7 @@ from wily.operators import Operator, resolve_operator
 from wily.state import State
 
 
-def gitignore_to_radon():
+def gitignore_to_radon() -> str:
     """Convert entries in a .gitignore file to radon ignore/exclude configs."""
     config = load_config(DEFAULT_CONFIG_PATH)
     gitignore_path = pathlib.Path(config.path) / ".gitignore"

--- a/src/wily/commands/build.py
+++ b/src/wily/commands/build.py
@@ -135,7 +135,10 @@ def build(config: WilyConfig, archiver: Archiver, operators: List[Operator]) -> 
                 # Run each operator as a separate process
                 data = pool.starmap(
                     run_operator,
-                    [(operator, revision, config, targets, ignore) for operator in operators],
+                    [
+                        (operator, revision, config, targets, ignore)
+                        for operator in operators
+                    ],
                 )
                 # data is a list of tuples, where for each operator, it is a tuple of length 2,
                 operator_data_len = 2

--- a/src/wily/commands/build.py
+++ b/src/wily/commands/build.py
@@ -14,19 +14,21 @@ from progress.bar import Bar
 from wily import logger
 from wily.archivers import Archiver, FilesystemArchiver, Revision
 from wily.archivers.git import InvalidGitRepositoryError
-from wily.config import load as load_config
 from wily.config.types import WilyConfig
-from wily.defaults import DEFAULT_CONFIG_PATH
 from wily.operators import Operator, resolve_operator
 from wily.state import State
 
 
-def gitignore_to_radon() -> str:
-    """Convert entries in a .gitignore file to radon ignore/exclude configs."""
-    config = load_config(DEFAULT_CONFIG_PATH)
-    gitignore_path = pathlib.Path(config.path) / ".gitignore"
+def gitignore_to_radon(path: str) -> str:
+    """
+    Convert entries in a .gitignore file to radon ignore/exclude configs.
+
+    :param path: The path where to find .gitignore.
+    :return: A comma-separated string containing glob patterns from .gitignore.
+    """
+    gitignore_path = pathlib.Path(path) / ".gitignore"
     if not gitignore_path.exists():
-        logger.info(f".gitignore file not found at {pathlib.Path(config.path)}")
+        logger.info(f".gitignore file not found at {pathlib.Path(path)}")
         return ""
     ignore = []
     with gitignore_path.open() as gitignore:
@@ -111,7 +113,7 @@ def build(config: WilyConfig, archiver: Archiver, operators: List[Operator]) -> 
     state.operators = operators
 
     # Get patterns to ignore from .gitignore
-    ignore = gitignore_to_radon()
+    ignore = gitignore_to_radon(config.path)
 
     # Index all files the first time, only scan changes afterward
     seed = True

--- a/src/wily/commands/build.py
+++ b/src/wily/commands/build.py
@@ -10,7 +10,6 @@ import pathlib
 from sys import exit
 from typing import Any, Dict, List, Tuple
 
-from git import Repo
 from progress.bar import Bar
 
 from wily import logger
@@ -26,8 +25,10 @@ from wily.state import State
 def gitignore_to_radon():
     """Convert entries in a .gitignore file to radon ignore/exclude configs."""
     config = load_config(DEFAULT_CONFIG_PATH)
-    repo = Repo(config.path)
-    gitignore_path = pathlib.Path(repo.git_dir) / ".gitignore"
+    gitignore_path = pathlib.Path(config.path) / ".gitignore"
+    if not gitignore_path.exists():
+        logger.info(f".gitignore file not found at {pathlib.Path(config.path)}")
+        return ""
     ignore = []
     with gitignore_path.open() as gitignore:
         for line in gitignore:

--- a/src/wily/commands/diff.py
+++ b/src/wily/commands/diff.py
@@ -95,7 +95,8 @@ def diff(
     # Build a set of operators
     with multiprocessing.Pool(processes=len(operators)) as pool:
         operator_exec_out = pool.starmap(
-            run_operator, [(operator, None, config, targets) for operator in operators]
+            run_operator,
+            [(operator, None, config, targets, "") for operator in operators],
         )
     data = {}
     for operator_name, result in operator_exec_out:

--- a/src/wily/operators/cyclomatic.py
+++ b/src/wily/operators/cyclomatic.py
@@ -43,7 +43,7 @@ class CyclomaticComplexityOperator(BaseOperator):
 
     default_metric_index = 0  # MI
 
-    def __init__(self, config, targets):
+    def __init__(self, config, targets, **kwargs):
         """
         Instantiate a new Cyclomatic Complexity operator.
 
@@ -53,6 +53,7 @@ class CyclomaticComplexityOperator(BaseOperator):
         # TODO: Import config for harvester from .wily.cfg
         logger.debug(f"Using {targets} with {self.defaults} for CC metrics")
 
+        self.defaults.update(kwargs)
         self.harvester = harvesters.CCHarvester(targets, config=Config(**self.defaults))
 
     def run(self, module, options):

--- a/src/wily/operators/halstead.py
+++ b/src/wily/operators/halstead.py
@@ -44,7 +44,7 @@ class HalsteadOperator(BaseOperator):
 
     default_metric_index = 0  # MI
 
-    def __init__(self, config, targets):
+    def __init__(self, config, targets, **kwargs):
         """
         Instantiate a new HC operator.
 
@@ -54,6 +54,7 @@ class HalsteadOperator(BaseOperator):
         # TODO : Import config from wily.cfg
         logger.debug(f"Using {targets} with {self.defaults} for HC metrics")
 
+        self.defaults.update(kwargs)
         self.harvester = harvesters.HCHarvester(targets, config=Config(**self.defaults))
 
     def run(self, module, options):

--- a/src/wily/operators/maintainability.py
+++ b/src/wily/operators/maintainability.py
@@ -52,7 +52,7 @@ class MaintainabilityIndexOperator(BaseOperator):
 
     default_metric_index = 1  # MI
 
-    def __init__(self, config, targets):
+    def __init__(self, config, targets, **kwargs):
         """
         Instantiate a new MI operator.
 
@@ -62,6 +62,7 @@ class MaintainabilityIndexOperator(BaseOperator):
         # TODO : Import config from wily.cfg
         logger.debug(f"Using {targets} with {self.defaults} for MI metrics")
 
+        self.defaults.update(kwargs)
         self.harvester = harvesters.MIHarvester(targets, config=Config(**self.defaults))
 
     def run(self, module, options):

--- a/src/wily/operators/raw.py
+++ b/src/wily/operators/raw.py
@@ -39,7 +39,7 @@ class RawMetricsOperator(BaseOperator):
     )
     default_metric_index = 0  # LOC
 
-    def __init__(self, config, targets):
+    def __init__(self, config, targets, **kwargs):
         """
         Instantiate a new raw operator.
 
@@ -48,6 +48,8 @@ class RawMetricsOperator(BaseOperator):
         """
         # TODO: Use config from wily.cfg for harvester
         logger.debug(f"Using {targets} with {self.defaults} for Raw metrics")
+
+        self.defaults.update(kwargs)
         self.harvester = harvesters.RawHarvester(
             targets, config=Config(**self.defaults)
         )


### PR DESCRIPTION
This PR addresses a TODO in build.py: "Convert .gitignore to radon ignore patterns to make the build more efficient". However, timings show no difference in performance even with a lot of added Python files in ignored directories. That happens because radon is called only with modified files from given revisions as targets, so the build is already optimal in this sense.

This PR serves only to document this exploration. Leaving it open for a while in case we can identify a scenario it would help with.