### PR TITLE
Restore displaying graph markers

### DIFF
--- a/src/wily/commands/graph.py
+++ b/src/wily/commands/graph.py
@@ -144,7 +144,7 @@ def graph(
             ids=state.index[state.default_archiver].revision_keys,
             text=labels,
             marker={
-                "size": 0 if z_axis is None else z,
+                "size": 0 if not z_axis else z,
                 "color": list(range(len(y))),
                 # "colorscale": "Viridis",
             },


### PR DESCRIPTION
When #205 landed, we stopped setting `z_axis` to `None`, but still test it against being `None`. This causes the `size`of `marker` to be an empty list instead of zero, hiding graph markers. This tiny PR fixes that.

Before:
![marker_before](https://github.com/tonybaloney/wily/assets/74280297/7f238bd4-83de-46ce-872d-647b4c042293)

After:
![marker_after](https://github.com/tonybaloney/wily/assets/74280297/5a172081-4e36-41cf-8ea7-c01a5e5872b8)

