### PR TITLE
Add line numbers for metrics in Cyclomatic and Halstead operators

### DIFF
--- a/src/wily/operators/cyclomatic.py
+++ b/src/wily/operators/cyclomatic.py
@@ -105,6 +105,8 @@ class CyclomaticComplexityOperator(BaseOperator):
             "complexity": l.complexity,
             "fullname": l.fullname,
             "loc": l.endline - l.lineno,
+            "lineno": l.lineno,
+            "endline": l.endline,
         }
 
     @staticmethod
@@ -116,4 +118,6 @@ class CyclomaticComplexityOperator(BaseOperator):
             "complexity": l.complexity,
             "fullname": l.fullname,
             "loc": l.endline - l.lineno,
+            "lineno": l.lineno,
+            "endline": l.endline,
         }

--- a/src/wily/operators/halstead.py
+++ b/src/wily/operators/halstead.py
@@ -3,12 +3,76 @@ Halstead operator.
 
 Measures all of the halstead metrics (volume, vocab, difficulty)
 """
+import ast
+import collections
+
 import radon.cli.harvest as harvesters
 from radon.cli import Config
+from radon.metrics import Halstead, HalsteadReport, halstead_visitor_report
+from radon.visitors import HalsteadVisitor
 
 from wily import logger
 from wily.lang import _
 from wily.operators import BaseOperator, Metric, MetricType
+
+NumberedHalsteadReport = collections.namedtuple(
+    "NumberedHalsteadReport",
+    HalsteadReport._fields + ("lineno", "endline"),
+)
+
+
+class NumberedHalsteadVisitor(HalsteadVisitor):
+    """HalsteadVisitor that adds class name, lineno and endline for code blocks."""
+
+    def __init__(self, context=None, lineno=None, endline=None, classname=None):
+        """
+        Initialize the numbered visitor.
+
+        :param context: Function/method name.
+        :param lineno: The starting line of the code block, if any.
+        :param endline: The ending line of the code block, if any.
+        :param classname: The class name for a method.
+        """
+        super().__init__(context)
+        self.lineno = lineno
+        self.endline = endline
+        self.class_name = classname
+
+    def visit_FunctionDef(self, node):
+        """Visit functions and methods, adding class name if any, lineno and endline."""
+        if self.class_name:
+            node.name = f"{self.class_name}.{node.name}"
+        super().visit_FunctionDef(node)
+        self.function_visitors[-1].lineno = node.lineno
+        self.function_visitors[-1].endline = node.end_lineno
+
+    def visit_ClassDef(self, node):
+        """Visit classes, adding class name and creating visitors for methods."""
+        self.class_name = node.name
+        for child in node.body:
+            visitor = NumberedHalsteadVisitor(classname=self.class_name)
+            visitor.visit(child)
+            self.function_visitors.extend(visitor.function_visitors)
+        self.class_name = None
+
+
+def number_report(visitor):
+    """Create a report with added lineno and endline."""
+    return NumberedHalsteadReport(
+        *(halstead_visitor_report(visitor) + (visitor.lineno, visitor.endline))
+    )
+
+
+class NumberedHCHarvester(harvesters.HCHarvester):
+    """Version of HCHarvester that adds lineno and endline."""
+
+    def gobble(self, fobj):
+        """Analyze the content of the file object, adding line numbers for blocks."""
+        code = fobj.read()
+        visitor = NumberedHalsteadVisitor.from_ast(ast.parse(code))
+        total = number_report(visitor)
+        functions = [(v.context, number_report(v)) for v in visitor.function_visitors]
+        return Halstead(total, functions)
 
 
 class HalsteadOperator(BaseOperator):
@@ -54,7 +118,7 @@ class HalsteadOperator(BaseOperator):
         # TODO : Import config from wily.cfg
         logger.debug(f"Using {targets} with {self.defaults} for HC metrics")
 
-        self.harvester = harvesters.HCHarvester(targets, config=Config(**self.defaults))
+        self.harvester = NumberedHCHarvester(targets, config=Config(**self.defaults))
 
     def run(self, module, options):
         """
@@ -100,4 +164,6 @@ class HalsteadOperator(BaseOperator):
             "length": report.length,
             "effort": report.effort,
             "difficulty": report.difficulty,
+            "lineno": report.lineno,
+            "endline": report.endline,
         }

--- a/src/wily/operators/halstead.py
+++ b/src/wily/operators/halstead.py
@@ -46,7 +46,9 @@ class NumberedHalsteadVisitor(HalsteadVisitor):
             node.name = f"{self.class_name}.{node.name}"
         super().visit_FunctionDef(node)
         self.function_visitors[-1].lineno = node.lineno
-        self.function_visitors[-1].endline = node.end_lineno
+        # FuncDef is missing end_lineno in Python 3.7
+        endline = node.end_lineno if hasattr(node, "end_lineno") else None
+        self.function_visitors[-1].endline = endline
 
     def visit_ClassDef(self, node):
         """Visit classes, adding class name and creating visitors for methods."""

--- a/src/wily/operators/halstead.py
+++ b/src/wily/operators/halstead.py
@@ -138,7 +138,7 @@ class HalsteadOperator(BaseOperator):
                 if isinstance(instance, list):
                     for item in instance:
                         function, report = item
-                        assert isinstance(report, HalsteadReport)
+                        assert isinstance(report, NumberedHalsteadReport)
                         results[filename]["detailed"][function] = self._report_to_dict(
                             report
                         )
@@ -150,11 +150,11 @@ class HalsteadOperator(BaseOperator):
                             details["error"],
                         )
                         continue
-                    assert isinstance(instance, HalsteadReport)
+                    assert isinstance(instance, NumberedHalsteadReport)
                     results[filename]["total"] = self._report_to_dict(instance)
         return results
 
-    def _report_to_dict(self, report: HalsteadReport) -> Dict[str, Any]:
+    def _report_to_dict(self, report: NumberedHalsteadReport) -> Dict[str, Any]:
         return {
             "h1": report.h1,
             "h2": report.h2,

--- a/test/integration/test_complex_commits.py
+++ b/test/integration/test_complex_commits.py
@@ -233,7 +233,9 @@ def test_metric_entries(tmpdir, cache_path):
     assert "lineno" in detailed_halstead["function1"]
     assert detailed_halstead["function1"]["lineno"] is not None
     assert "endline" in detailed_halstead["function1"]
-    assert detailed_halstead["function1"]["endline"] is not None
+    if sys.version_info > (3, 7):
+        # FuncDef is missing end_lineno in Python 3.7
+        assert detailed_halstead["function1"]["endline"] is not None
 
     assert "Class1" not in detailed_halstead
 

--- a/test/integration/test_complex_commits.py
+++ b/test/integration/test_complex_commits.py
@@ -243,7 +243,8 @@ def test_metric_entries(tmpdir, cache_path):
     assert "lineno" in detailed_halstead["Class1.method"]
     assert detailed_halstead["Class1.method"]["lineno"] is not None
     assert "endline" in detailed_halstead["Class1.method"]
-    assert detailed_halstead["Class1.method"]["endline"] is not None
+    if sys.version_info >= (3, 8):
+        assert detailed_halstead["Class1.method"]["endline"] is not None
 
     expected_raw_total = {
         "loc": 14,

--- a/test/integration/test_complex_commits.py
+++ b/test/integration/test_complex_commits.py
@@ -112,3 +112,149 @@ def test_skip_files(tmpdir, cache_path):
     assert "raw" in data3["operator_data"]
     assert _path1 in data3["operator_data"]["raw"]
     assert _path2 in data3["operator_data"]["raw"]
+
+
+complex_test = """
+import abc
+foo = 1
+def function1():
+    a = 1 + 1
+    if a == 2:
+        print(1)
+class Class1(object):
+    def method(self):
+        b = 1 + 5
+        if b == 6:
+            if 1==2:
+               if 2==3:
+                  print(1)
+"""
+
+
+def test_metric_entries(tmpdir, cache_path):
+    """Test that the expected fields and values are present in metric results."""
+    repo = Repo.init(path=tmpdir)
+    tmppath = pathlib.Path(tmpdir) / "src"
+    tmppath.mkdir()
+
+    # Write and commit one test file to the repo
+    with open(tmppath / "test1.py", "w") as test1_txt:
+        test1_txt.write(complex_test)
+    index = repo.index
+    index.add([str(tmppath / "test1.py")])
+    author = Actor("An author", "author@example.com")
+    committer = Actor("A committer", "committer@example.com")
+    commit = index.commit("commit one file", author=author, committer=committer)
+    repo.close()
+
+    # Build the wily cache
+    runner = CliRunner()
+    result = runner.invoke(
+        main.cli,
+        ["--debug", "--path", tmpdir, "--cache", cache_path, "build", str(tmppath)],
+    )
+    assert result.exit_code == 0, result.stdout
+
+    # Get the revision path and the revision data
+    cache_path = pathlib.Path(cache_path)
+    rev_path = cache_path / "git" / (commit.name_rev.split(" ")[0] + ".json")
+    assert rev_path.exists()
+    with open(rev_path) as rev_file:
+        data = json.load(rev_file)
+
+    # Check that basic data format is correct
+    assert "cyclomatic" in data["operator_data"]
+    assert _path1 in data["operator_data"]["cyclomatic"]
+    assert "detailed" in data["operator_data"]["cyclomatic"][_path1]
+    assert "total" in data["operator_data"]["cyclomatic"][_path1]
+
+    # Test total and detailed metrics
+    expected_cyclomatic_total = {"complexity": 11}
+    total_cyclomatic = data["operator_data"]["cyclomatic"][_path1]["total"]
+    assert total_cyclomatic == expected_cyclomatic_total
+
+    detailed_cyclomatic = data["operator_data"]["cyclomatic"][_path1]["detailed"]
+    assert "function1" in detailed_cyclomatic
+    assert "lineno" in detailed_cyclomatic["function1"]
+    assert "endline" in detailed_cyclomatic["function1"]
+    expected_cyclomatic_function1 = {
+        "name": "function1",
+        "is_method": False,
+        "classname": None,
+        "closures": [],
+        "complexity": 2,
+        "loc": 3,
+        "lineno": 4,
+        "endline": 7,
+    }
+    assert detailed_cyclomatic["function1"] == expected_cyclomatic_function1
+
+    expected_cyclomatic_Class1 = {
+        "name": "Class1",
+        "inner_classes": [],
+        "real_complexity": 5,
+        "complexity": 5,
+        "loc": 6,
+        "lineno": 8,
+        "endline": 14,
+    }
+    assert detailed_cyclomatic["Class1"] == expected_cyclomatic_Class1
+
+    expected_cyclomatic_method = {
+        "name": "method",
+        "is_method": True,
+        "classname": "Class1",
+        "closures": [],
+        "complexity": 4,
+        "loc": 5,
+        "lineno": 9,
+        "endline": 14,
+    }
+    assert detailed_cyclomatic["Class1.method"] == expected_cyclomatic_method
+
+    expected_halstead_total = {
+        "h1": 2,
+        "h2": 3,
+        "N1": 2,
+        "N2": 4,
+        "vocabulary": 5,
+        "volume": 13.931568569324174,
+        "length": 6,
+        "effort": 18.575424759098897,
+        "difficulty": 1.3333333333333333,
+        "lineno": None,
+        "endline": None,
+    }
+    total_halstead = data["operator_data"]["halstead"][_path1]["total"]
+    assert total_halstead == expected_halstead_total
+
+    detailed_halstead = data["operator_data"]["halstead"][_path1]["detailed"]
+    assert "function1" in detailed_halstead
+    assert "lineno" in detailed_halstead["function1"]
+    assert detailed_halstead["function1"]["lineno"] is not None
+    assert "endline" in detailed_halstead["function1"]
+    assert detailed_halstead["function1"]["endline"] is not None
+
+    assert "Class1" not in detailed_halstead
+
+    assert "Class1.method" in detailed_halstead
+    assert "lineno" in detailed_halstead["Class1.method"]
+    assert detailed_halstead["Class1.method"]["lineno"] is not None
+    assert "endline" in detailed_halstead["Class1.method"]
+    assert detailed_halstead["Class1.method"]["endline"] is not None
+
+    expected_raw_total = {
+        "loc": 14,
+        "lloc": 13,
+        "sloc": 13,
+        "comments": 0,
+        "multi": 0,
+        "blank": 1,
+        "single_comments": 0,
+    }
+    total_raw = data["operator_data"]["raw"][_path1]["total"]
+    assert total_raw == expected_raw_total
+
+    expected_maintainability = {"mi": 62.3299092923013, "rank": "A"}
+    total_maintainability = data["operator_data"]["maintainability"][_path1]["total"]
+    assert total_maintainability == expected_maintainability

--- a/test/integration/test_complex_commits.py
+++ b/test/integration/test_complex_commits.py
@@ -233,7 +233,7 @@ def test_metric_entries(tmpdir, cache_path):
     assert "lineno" in detailed_halstead["function1"]
     assert detailed_halstead["function1"]["lineno"] is not None
     assert "endline" in detailed_halstead["function1"]
-    if sys.version_info > (3, 7):  # noqa: UP036
+    if sys.version_info >= (3, 8):
         # FuncDef is missing end_lineno in Python 3.7
         assert detailed_halstead["function1"]["endline"] is not None
 

--- a/test/integration/test_complex_commits.py
+++ b/test/integration/test_complex_commits.py
@@ -233,7 +233,7 @@ def test_metric_entries(tmpdir, cache_path):
     assert "lineno" in detailed_halstead["function1"]
     assert detailed_halstead["function1"]["lineno"] is not None
     assert "endline" in detailed_halstead["function1"]
-    if sys.version_info > (3, 7):
+    if sys.version_info > (3, 7):  # noqa: UP036
         # FuncDef is missing end_lineno in Python 3.7
         assert detailed_halstead["function1"]["endline"] is not None
 


### PR DESCRIPTION
As a first step to address #217, allowing wily to generate annotated source listings with inline visualization of code metrics, we need to record line numbers for code blocks when building the cache.

Radon already supplies line numbers (lineno and endline) for Cyclomatic Complexity, so we just record those in the detailed metrics.

For Halstead line numbers, we need to customize visitor, harvester and some other pieces. [PRs](https://github.com/rubik/radon/pull/247) and [issues](https://github.com/rubik/radon/issues/248) upstreaming this work have already started being submitted to radon.

This PR is necessary regardless of whether the `annotate` feature lands as a command or is kept as a separate tool.