### PR TITLE
Lazy-format all logging calls (fix #219)

### DIFF
--- a/src/wily/__main__.py
+++ b/src/wily/__main__.py
@@ -83,13 +83,13 @@ def cli(ctx, debug, config, path, cache):
 
     ctx.obj["CONFIG"] = load_config(config)
     if path:
-        logger.debug(f"Fixing path to {path}")
+        logger.debug("Fixing path to %s", path)
         ctx.obj["CONFIG"].path = path
     if cache:
-        logger.debug(f"Fixing cache to {cache}")
+        logger.debug("Fixing cache to %s", cache)
         ctx.obj["CONFIG"].cache_path = cache
-    logger.debug(f"Loaded configuration from {config}")
-    logger.debug(f"Capturing logs to {WILY_LOG_NAME}")
+    logger.debug("Loaded configuration from %s", config)
+    logger.debug("Capturing logs to %s", WILY_LOG_NAME)
 
 
 @cli.command(help=_("""Build the wily cache."""))
@@ -122,19 +122,19 @@ def build(ctx, max_revisions, targets, operators, archiver):
     from wily.commands.build import build
 
     if max_revisions:
-        logger.debug(f"Fixing revisions to {max_revisions}")
+        logger.debug("Fixing revisions to %s", max_revisions)
         config.max_revisions = max_revisions
 
     if operators:
-        logger.debug(f"Fixing operators to {operators}")
+        logger.debug("Fixing operators to %s", operators)
         config.operators = operators.strip().split(",")
 
     if archiver:
-        logger.debug(f"Fixing archiver to {archiver}")
+        logger.debug("Fixing archiver to %s", archiver)
         config.archiver = archiver
 
     if targets:
-        logger.debug(f"Fixing targets to {targets}")
+        logger.debug("Fixing targets to %s", targets)
         config.targets = targets
 
     build(
@@ -228,7 +228,9 @@ def rank(ctx, path, metric, revision, limit, desc, threshold, wrap):
 
     from wily.commands.rank import rank
 
-    logger.debug(f"Running rank on {path} for metric {metric} and revision {revision}")
+    logger.debug(
+        "Running rank on %s for metric %s and revision %s", path, metric, revision
+    )
     rank(
         config=config,
         path=path,
@@ -291,7 +293,7 @@ def report(
 
     if not metrics:
         metrics = get_default_metrics(config)
-        logger.info(f"Using default metrics {metrics}")
+        logger.info("Using default metrics %s", metrics)
 
     new_output = Path().cwd()
     if output:
@@ -303,8 +305,8 @@ def report(
 
     from wily.commands.report import report
 
-    logger.debug(f"Running report on {file} for metric {metrics}")
-    logger.debug(f"Output format is {format}")
+    logger.debug("Running report on %s for metric %s", file, metrics)
+    logger.debug("Output format is %s", format)
 
     report(
         config=config,
@@ -358,14 +360,14 @@ def diff(ctx, files, metrics, all, detail, revision, wrap):
 
     if not metrics:
         metrics = get_default_metrics(config)
-        logger.info(f"Using default metrics {metrics}")
+        logger.info("Using default metrics %s", metrics)
     else:
         metrics = metrics.split(",")
-        logger.info(f"Using specified metrics {metrics}")
+        logger.info("Using specified metrics %s", metrics)
 
     from wily.commands.diff import diff
 
-    logger.debug(f"Running diff on {files} for metric {metrics}")
+    logger.debug("Running diff on %s for metric %s", files, metrics)
     diff(
         config=config,
         files=files,
@@ -430,7 +432,7 @@ def graph(ctx, path, metrics, output, x_axis, changes, aggregate):
 
     from wily.commands.graph import graph
 
-    logger.debug(f"Running report on {path} for metrics {metrics}")
+    logger.debug("Running report on %s for metrics %s", path, metrics)
     graph(
         config=config,
         path=path,
@@ -510,7 +512,7 @@ if __name__ == "__main__":  # pragma: no cover
     try:
         cli()  # type: ignore
     except Exception as runtime:
-        logger.error(f"Oh no, Wily crashed! See {WILY_LOG_NAME} for information.")
+        logger.error("Oh no, Wily crashed! See %s for information.", WILY_LOG_NAME)
         logger.info(
             "If you think this crash was unexpected, please raise an issue at https://github.com/tonybaloney/wily/issues and copy the log file into the issue report along with some information on what you were doing."
         )

--- a/src/wily/archivers/git.py
+++ b/src/wily/archivers/git.py
@@ -123,12 +123,12 @@ class GitArchiver(BaseArchiver):
                     commit, self.repo.commit(commit.hexsha + "~1")
                 )
 
-            logger.debug(f"For revision {commit.name_rev.split(' ')[0]} found:")
-            logger.debug(f"Tracked files: {tracked_files}")
-            logger.debug(f"Tracked directories: {tracked_dirs}")
-            logger.debug(f"Added files: {added_files}")
-            logger.debug(f"Modified files: {modified_files}")
-            logger.debug(f"Deleted files: {deleted_files}")
+            logger.debug("For revision %s found:", commit.name_rev.split(" ")[0])
+            logger.debug("Tracked files: %s", tracked_files)
+            logger.debug("Tracked directories: %s", tracked_dirs)
+            logger.debug("Added files: %s", added_files)
+            logger.debug("Modified files: %s", modified_files)
+            logger.debug("Deleted files: %s", deleted_files)
 
             rev = Revision(
                 key=commit.name_rev.split(" ")[0],

--- a/src/wily/cache.py
+++ b/src/wily/cache.py
@@ -68,7 +68,7 @@ def create(config: WilyConfig) -> str:
     if exists(config):
         logger.debug("Wily cache exists, skipping")
         return config.cache_path
-    logger.debug(f"Creating wily cache {config.cache_path}")
+    logger.debug("Creating wily cache %s", config.cache_path)
     pathlib.Path(config.cache_path).mkdir(parents=True, exist_ok=True)
     create_index(config)
     return config.cache_path
@@ -124,7 +124,7 @@ def store(
                 del stats["operator_data"][operator]
                 stats["operator_data"][operator] = new_operator_data
 
-    logger.debug(f"Creating {revision.key} output")
+    logger.debug("Creating %s output", revision.key)
     filename = root / (revision.key + ".json")
     if filename.exists():
         raise RuntimeError(f"File {filename} already exists, index may be corrupt.")

--- a/src/wily/commands/build.py
+++ b/src/wily/commands/build.py
@@ -32,7 +32,7 @@ def run_operator(
     :param targets: Files/paths to scan
     """
     instance = operator.operator_cls(config, targets)
-    logger.debug(f"Running {operator.name} operator on {revision}")
+    logger.debug("Running %s operator on %s", operator.name, revision)
 
     data = instance.run(revision, config)
 
@@ -55,7 +55,7 @@ def build(config: WilyConfig, archiver: Archiver, operators: List[Operator]) -> 
     :param operators: The list of operators to execute
     """
     try:
-        logger.debug(f"Using {archiver.name} archiver module")
+        logger.debug("Using %s archiver module", archiver.name)
         archiver_instance = archiver.archiver_cls(config)
         revisions = archiver_instance.revisions(config.path, config.max_revisions)
     except InvalidGitRepositoryError:
@@ -65,7 +65,7 @@ def build(config: WilyConfig, archiver: Archiver, operators: List[Operator]) -> 
         revisions = archiver_instance.revisions(config.path, config.max_revisions)
     except Exception as e:
         message = getattr(e, "message", f"{type(e)} - {e}")
-        logger.error(f"Failed to setup archiver: '{message}'")
+        logger.error("Failed to setup archiver: '%s'", message)
         exit(1)
 
     state = State(config, archiver=archiver_instance)
@@ -78,11 +78,14 @@ def build(config: WilyConfig, archiver: Archiver, operators: List[Operator]) -> 
     revisions = [revision for revision in revisions if revision not in index][::-1]
 
     logger.info(
-        f"Found {len(revisions)} revisions from '{archiver_instance.name}' archiver in '{config.path}'."
+        "Found %s revisions from '%s' archiver in '%s'.",
+        len(revisions),
+        archiver_instance.name,
+        config.path,
     )
 
     _op_desc = ",".join([operator.name for operator in operators])
-    logger.info(f"Running operators - {_op_desc}")
+    logger.info("Running operators - %s", _op_desc)
 
     bar = Bar("Processing", max=len(revisions) * len(operators))
     state.operators = operators
@@ -120,7 +123,9 @@ def build(config: WilyConfig, archiver: Archiver, operators: List[Operator]) -> 
                         and len(data[i][1]) == 0
                     ):
                         logger.warning(
-                            f"In revision {revision.key}, for operator {operators[i].name}: No data collected"
+                            "In revision %s, for operator %s: No data collected",
+                            revision.key,
+                            operators[i].name,
                         )
 
                 # Map the data back into a dictionary
@@ -197,7 +202,7 @@ def build(config: WilyConfig, archiver: Archiver, operators: List[Operator]) -> 
         index.save()
         bar.finish()
     except Exception as e:
-        logger.error(f"Failed to build cache: {type(e)}: '{e}'")
+        logger.error("Failed to build cache: %s: '%s'", type(e), e)
         raise e
     finally:
         # Reset the archive after every run back to the head of the branch

--- a/src/wily/commands/diff.py
+++ b/src/wily/commands/diff.py
@@ -64,7 +64,7 @@ def diff(
         os.path.relpath(fn, config.path)
         for fn in radon.cli.harvest.iter_filenames(targets)
     ]
-    logger.debug(f"Targeting - {files}")
+    logger.debug("Targeting - %s", files)
 
     if not revision:
         target_revision = state.index[state.default_archiver].last_revision
@@ -72,17 +72,21 @@ def diff(
         rev = (
             resolve_archiver(state.default_archiver).archiver_cls(config).find(revision)
         )
-        logger.debug(f"Resolved {revision} to {rev.key} ({rev.message})")
+        logger.debug("Resolved %s to %s (%s)", revision, rev.key, rev.message)
         try:
             target_revision = state.index[state.default_archiver][rev.key]
         except KeyError:
             logger.error(
-                f"Revision {revision} is not in the cache, make sure you have run wily build."
+                "Revision %s is not in the cache, make sure you have run wily build.",
+                revision,
             )
             exit(1)
 
     logger.info(
-        f"Comparing current with {format_revision(target_revision.revision.key)} by {target_revision.revision.author_name} on {format_date(target_revision.revision.date)}."
+        "Comparing current with %s by %s on %s.",
+        format_revision(target_revision.revision.key),
+        target_revision.revision.author_name,
+        format_date(target_revision.revision.date),
     )
 
     # Convert the list of metrics to a list of metric instances
@@ -116,7 +120,7 @@ def diff(
                         ]
                     )
                 except KeyError:
-                    logger.debug(f"File {file} not in cache")
+                    logger.debug("File %s not in cache", file)
                     logger.debug("Cache follows -- ")
                     logger.debug(data[operator])
     files.extend(extra)

--- a/src/wily/commands/index.py
+++ b/src/wily/commands/index.py
@@ -24,9 +24,9 @@ def index(
     state = State(config=config)
     logger.debug("Running show command")
     logger.info("--------Configuration---------")
-    logger.info(f"Path: {config.path}")
-    logger.info(f"Archiver: {config.archiver}")
-    logger.info(f"Operators: {config.operators}")
+    logger.info("Path: %s", config.path)
+    logger.info("Archiver: %s", config.archiver)
+    logger.info("Operators: %s", config.operators)
     logger.info("")
     logger.info("-----------History------------")
 

--- a/src/wily/commands/rank.py
+++ b/src/wily/commands/rank.py
@@ -64,22 +64,27 @@ def rank(
             .archiver_cls(config)
             .find(revision_index)
         )
-        logger.debug(f"Resolved {revision_index} to {rev.key} ({rev.message})")
+        logger.debug("Resolved %s to %s (%s)", revision_index, rev.key, rev.message)
         try:
             target_revision = state.index[state.default_archiver][rev.key]
         except KeyError:
             logger.error(
-                f"Revision {revision_index} is not in the cache, make sure you have run wily build."
+                "Revision %s is not in the cache, make sure you have run wily build.",
+                revision_index,
             )
             exit(1)
 
     logger.info(
-        f"-----------Rank for {resolved_metric.description} for {format_revision(target_revision.revision.key)} by {target_revision.revision.author_name} on {format_date(target_revision.revision.date)}.------------"
+        "-----------Rank for %s for %s by %s on %s.------------",
+        resolved_metric.description,
+        format_revision(target_revision.revision.key),
+        target_revision.revision.author_name,
+        format_date(target_revision.revision.date),
     )
 
     if path is None:
         files = target_revision.get_paths(config, state.default_archiver, operator)
-        logger.debug(f"Analysing {files}")
+        logger.debug("Analysing %s", files)
     else:
         # Resolve target paths when the cli has specified --path
         if config.path != DEFAULT_PATH:
@@ -92,13 +97,16 @@ def rank(
             os.path.relpath(fn, config.path)
             for fn in radon.cli.harvest.iter_filenames(targets)
         ]
-        logger.debug(f"Targeting - {files}")
+        logger.debug("Targeting - %s", files)
 
     for item in files:
         for archiver in state.archivers:
             try:
                 logger.debug(
-                    f"Fetching metric {resolved_metric.name} for {operator} in {str(item)}"
+                    "Fetching metric %s for %s in %s",
+                    resolved_metric.name,
+                    operator,
+                    str(item),
                 )
                 val = target_revision.get(
                     config, archiver, operator, str(item), resolved_metric.name
@@ -106,7 +114,7 @@ def rank(
                 value = val
                 data.append((item, value))
             except KeyError:
-                logger.debug(f"Could not find file {item} in index")
+                logger.debug("Could not find file %s in index", item)
 
     # Sort by ideal value
     data = sorted(data, key=op.itemgetter(1), reverse=descending)
@@ -136,6 +144,6 @@ def rank(
 
     if threshold and total < threshold:
         logger.error(
-            f"Total value below the specified threshold: {total} < {threshold}"
+            "Total value below the specified threshold: %s < %s", total, threshold
         )
         exit(1)

--- a/src/wily/commands/report.py
+++ b/src/wily/commands/report.py
@@ -54,7 +54,7 @@ def report(
     """
     metrics = sorted(metrics)
     logger.debug("Running report command")
-    logger.info(f"-----------History for {metrics}------------")
+    logger.info("-----------History for %s------------", metrics)
 
     data = []
     metric_metas = []
@@ -96,7 +96,10 @@ def report(
             for meta in metric_metas:
                 try:
                     logger.debug(
-                        f"Fetching metric {meta['key']} for {meta['operator']} in {path}"
+                        "Fetching metric %s for %s in %s",
+                        meta["key"],
+                        meta["operator"],
+                        path,
                     )
                     val = rev.get(config, archiver, meta["operator"], path, meta["key"])
 
@@ -153,7 +156,7 @@ def report(
                         )
                     )
     if not data:
-        logger.error(f"No data found for {path} with changes={changes_only}.")
+        logger.error("No data found for %s with changes=%s.", path, changes_only)
         return
 
     descriptions = [meta["title"] for meta in metric_metas]
@@ -199,7 +202,7 @@ def report(
         except FileExistsError:
             pass
 
-        logger.info(f"wily report was saved to {report_path}")
+        logger.info("wily report was saved to %s", report_path)
     else:
         maxcolwidth = get_maxcolwidth(headers, wrap)
         print(

--- a/src/wily/config/__init__.py
+++ b/src/wily/config/__init__.py
@@ -50,7 +50,7 @@ def load(config_path=DEFAULT_CONFIG_PATH):
     :rtype: :class:`wily.config.WilyConfig`
     """
     if not pathlib.Path(config_path).exists():
-        logger.debug(f"Could not locate {config_path}, using default config.")
+        logger.debug("Could not locate %s, using default config.", config_path)
         return DEFAULT_CONFIG
 
     config = configparser.ConfigParser(default_section=DEFAULT_CONFIG_SECTION)

--- a/src/wily/config/types.py
+++ b/src/wily/config/types.py
@@ -47,7 +47,7 @@ class WilyConfig:
     @cache_path.setter
     def cache_path(self, value):
         """Override the cache path."""
-        logger.debug(f"Setting custom cache path to {value}")
+        logger.debug("Setting custom cache path to %s", value)
         self._cache_path = value  # type: ignore
 
     @staticmethod

--- a/src/wily/helper/__init__.py
+++ b/src/wily/helper/__init__.py
@@ -48,9 +48,9 @@ def generate_cache_path(path: Union[pathlib.Path, str]) -> str:
 
     :return: The cache path
     """
-    logger.debug(f"Generating cache for {path}")
+    logger.debug("Generating cache for %s", path)
     sha = hashlib.sha1(str(path).encode()).hexdigest()[:9]
     HOME = pathlib.Path.home()
     cache_path = str(HOME / ".wily" / sha)
-    logger.debug(f"Cache path is {cache_path}")
+    logger.debug("Cache path is %s", cache_path)
     return cache_path

--- a/src/wily/operators/cyclomatic.py
+++ b/src/wily/operators/cyclomatic.py
@@ -51,7 +51,7 @@ class CyclomaticComplexityOperator(BaseOperator):
         :type  config: :class:`WilyConfig`
         """
         # TODO: Import config for harvester from .wily.cfg
-        logger.debug(f"Using {targets} with {self.defaults} for CC metrics")
+        logger.debug("Using %s with %s for CC metrics", targets, self.defaults)
 
         self.harvester = harvesters.CCHarvester(targets, config=Config(**self.defaults))
 
@@ -81,12 +81,16 @@ class CyclomaticComplexityOperator(BaseOperator):
                 else:
                     if isinstance(instance, str) and instance == "error":
                         logger.debug(
-                            f"Failed to run CC harvester on {filename} : {details['error']}"
+                            "Failed to run CC harvester on %s : %s",
+                            filename,
+                            details["error"],
                         )
                         continue
                     else:
                         logger.warning(
-                            f"Unexpected result from Radon : {instance} of {type(instance)}. Please report on Github."
+                            "Unexpected result from Radon : %s of %s. Please report on Github.",
+                            instance,
+                            type(instance),
                         )
                         continue
                 results[filename]["detailed"][i["fullname"]] = i

--- a/src/wily/operators/halstead.py
+++ b/src/wily/operators/halstead.py
@@ -52,7 +52,7 @@ class HalsteadOperator(BaseOperator):
         :type  config: :class:`WilyConfig`
         """
         # TODO : Import config from wily.cfg
-        logger.debug(f"Using {targets} with {self.defaults} for HC metrics")
+        logger.debug("Using %s with %s for HC metrics", targets, self.defaults)
 
         self.harvester = harvesters.HCHarvester(targets, config=Config(**self.defaults))
 
@@ -83,7 +83,9 @@ class HalsteadOperator(BaseOperator):
                 else:
                     if isinstance(instance, str) and instance == "error":
                         logger.debug(
-                            f"Failed to run Halstead harvester on {filename} : {details['error']}"
+                            "Failed to run Halstead harvester on %s : %s",
+                            filename,
+                            details["error"],
                         )
                         continue
                     results[filename]["total"] = self._report_to_dict(instance)

--- a/src/wily/operators/maintainability.py
+++ b/src/wily/operators/maintainability.py
@@ -60,7 +60,7 @@ class MaintainabilityIndexOperator(BaseOperator):
         :type  config: :class:`WilyConfig`
         """
         # TODO : Import config from wily.cfg
-        logger.debug(f"Using {targets} with {self.defaults} for MI metrics")
+        logger.debug("Using %s with %s for MI metrics", targets, self.defaults)
 
         self.harvester = harvesters.MIHarvester(targets, config=Config(**self.defaults))
 

--- a/src/wily/operators/raw.py
+++ b/src/wily/operators/raw.py
@@ -47,7 +47,7 @@ class RawMetricsOperator(BaseOperator):
         :type  config: :class:`WilyConfig`
         """
         # TODO: Use config from wily.cfg for harvester
-        logger.debug(f"Using {targets} with {self.defaults} for Raw metrics")
+        logger.debug("Using %s with %s for Raw metrics", targets, self.defaults)
         self.harvester = harvesters.RawHarvester(
             targets, config=Config(**self.defaults)
         )

--- a/src/wily/state.py
+++ b/src/wily/state.py
@@ -62,7 +62,7 @@ class IndexedRevision:
             self._data = cache.get(
                 config=config, archiver=archiver, revision=self.revision.key
             )["operator_data"]
-        logger.debug(f"Fetching metric {path} - {key} for operator {operator}")
+        logger.debug("Fetching metric %s - %s for operator %s", path, key, operator)
         return get_metric(self._data, operator, path, key)
 
     def get_paths(self, config: WilyConfig, archiver: str, operator: str) -> List[str]:
@@ -203,7 +203,7 @@ class State:
             self.archivers = [archiver.name]
         else:
             self.archivers = cache.list_archivers(config)
-        logger.debug(f"Initialised state indexes for archivers {self.archivers}")
+        logger.debug("Initialised state indexes for archivers %s", self.archivers)
         self.config = config
         self.index = {}
         for _archiver in self.archivers:
@@ -217,4 +217,4 @@ class State:
             cache.create(self.config)
             logger.debug("Created wily cache")
         else:
-            logger.debug(f"Cache {self.config.cache_path} exists")
+            logger.debug("Cache %s exists", self.config.cache_path)


### PR DESCRIPTION
This PR converts wily's logging from using f-strings to `%` style messages.
Fixes #219.