### PR TITLE
Only analyze files that are children of the targets in build()

### DIFF
--- a/src/wily/commands/build.py
+++ b/src/wily/commands/build.py
@@ -103,7 +103,9 @@ def build(config: WilyConfig, archiver: Archiver, operators: List[Operator]) -> 
                 targets = [
                     str(pathlib.Path(config.path) / pathlib.Path(file))
                     for file in revision.added_files + revision.modified_files
-                    if any(  # Check that changed files are children of the targets
+                    if not config.targets
+                    or any(
+                        # Check that changed files are children of the targets
                         True
                         for target in config.targets
                         if pathlib.Path(target)

--- a/src/wily/commands/build.py
+++ b/src/wily/commands/build.py
@@ -7,6 +7,7 @@ TODO : Convert .gitignore to radon ignore patterns to make the build more effici
 import multiprocessing
 import os
 import pathlib
+from collections.abc import Sequence
 from sys import exit
 from typing import Any, Dict, List, Tuple
 
@@ -95,7 +96,7 @@ def build(config: WilyConfig, archiver: Archiver, operators: List[Operator]) -> 
     try:
         with multiprocessing.Pool(processes=len(operators)) as pool:
             prev_stats: Dict[str, Dict] = {}
-            assert isinstance(config.targets, list)
+            assert isinstance(config.targets, Sequence)
             for revision in revisions:
                 # Checkout target revision
                 archiver_instance.checkout(revision, config.checkout_options)

--- a/src/wily/commands/build.py
+++ b/src/wily/commands/build.py
@@ -40,6 +40,7 @@ def run_operator(
     # Normalize paths for non-seed passes
     for key in list(data.keys()):
         if os.path.isabs(key):
+            # ToDo: Handle paths on different drives in Windows
             rel = os.path.relpath(key, config.path)
             data[rel] = data[key]
             del data[key]

--- a/src/wily/commands/build.py
+++ b/src/wily/commands/build.py
@@ -103,7 +103,7 @@ def build(config: WilyConfig, archiver: Archiver, operators: List[Operator]) -> 
                 targets = [
                     str(pathlib.Path(config.path) / pathlib.Path(file))
                     for file in revision.added_files + revision.modified_files
-                    if config.targets == ["."]
+                    if config.targets == ["."]  # Add all files if no target is set
                     or any(
                         # Check that changed files are children of the targets
                         True

--- a/src/wily/commands/build.py
+++ b/src/wily/commands/build.py
@@ -111,7 +111,7 @@ def build(config: WilyConfig, archiver: Archiver, operators: List[Operator]) -> 
                         # Check that changed files are children of the targets
                         True
                         for target in config.targets
-                        if pathlib.Path(target)
+                        if pathlib.Path(target).resolve()
                         in (pathlib.Path(config.path) / file).parents
                     )
                 ]

--- a/src/wily/commands/build.py
+++ b/src/wily/commands/build.py
@@ -103,7 +103,7 @@ def build(config: WilyConfig, archiver: Archiver, operators: List[Operator]) -> 
                 targets = [
                     str(pathlib.Path(config.path) / pathlib.Path(file))
                     for file in revision.added_files + revision.modified_files
-                    if not config.targets
+                    if config.targets == ["."]
                     or any(
                         # Check that changed files are children of the targets
                         True

--- a/src/wily/commands/build.py
+++ b/src/wily/commands/build.py
@@ -112,7 +112,7 @@ def build(config: WilyConfig, archiver: Archiver, operators: List[Operator]) -> 
                         True
                         for target in config.targets
                         if pathlib.Path(target).resolve()
-                        in (pathlib.Path(config.path) / file).parents
+                        in (pathlib.Path(config.path).resolve() / file).parents
                     )
                 ]
 

--- a/src/wily/commands/build.py
+++ b/src/wily/commands/build.py
@@ -98,7 +98,7 @@ def build(config: WilyConfig, archiver: Archiver, operators: List[Operator]) -> 
         with multiprocessing.Pool(processes=len(operators)) as pool:
             prev_stats: Dict[str, Dict] = {}
             assert isinstance(config.targets, Sequence)
-            parents = (pathlib.Path(config.path).resolve()).parents
+            resolved_path = pathlib.Path(config.path).resolve()
             resolved_targets = [
                 pathlib.Path(target).resolve() for target in config.targets
             ]
@@ -112,7 +112,11 @@ def build(config: WilyConfig, archiver: Archiver, operators: List[Operator]) -> 
                     for file in revision.added_files + revision.modified_files
                     if config.targets == ["."]  # Add all files if no target is set
                     # Check that changed files are children of the targets
-                    or any(True for target in resolved_targets if target in parents)
+                    or any(
+                        True
+                        for target in resolved_targets
+                        if target in (resolved_path / file).parents
+                    )
                 ]
 
                 # Run each operator as a separate process

--- a/src/wily/commands/build.py
+++ b/src/wily/commands/build.py
@@ -100,12 +100,15 @@ def build(config: WilyConfig, archiver: Archiver, operators: List[Operator]) -> 
                 archiver_instance.checkout(revision, config.checkout_options)
                 stats: Dict[str, Dict] = {"operator_data": {}}
 
-                # TODO : Check that changed files are children of the targets
                 targets = [
                     str(pathlib.Path(config.path) / pathlib.Path(file))
                     for file in revision.added_files + revision.modified_files
-                    # if any([True for target in config.targets if
-                    #         target in pathlib.Path(pathlib.Path(config.path) / pathlib.Path(file)).parents])
+                    if any(  # Check that changed files are children of the targets
+                        True
+                        for target in config.targets
+                        if pathlib.Path(target)
+                        in (pathlib.Path(config.path) / file).parents
+                    )
                 ]
 
                 # Run each operator as a separate process

--- a/src/wily/commands/build.py
+++ b/src/wily/commands/build.py
@@ -95,6 +95,7 @@ def build(config: WilyConfig, archiver: Archiver, operators: List[Operator]) -> 
     try:
         with multiprocessing.Pool(processes=len(operators)) as pool:
             prev_stats: Dict[str, Dict] = {}
+            assert isinstance(config.targets, list)
             for revision in revisions:
                 # Checkout target revision
                 archiver_instance.checkout(revision, config.checkout_options)

--- a/test/unit/test_build_unit.py
+++ b/test/unit/test_build_unit.py
@@ -80,7 +80,7 @@ def test_build_simple(config):
     assert result is None
 
 
-def test_build_targets(config):
+def test_build_targets():
     mock_state = MagicMock()
     mock_starmap = MagicMock()
     mock_pool = MagicMock()
@@ -88,11 +88,13 @@ def test_build_targets(config):
     mock_pool.__enter__.return_value = mock_pool
     mock_pool.starmap = mock_starmap
 
+    config = DEFAULT_CONFIG
+    config.path = "."
     _test_operators = (MockOperator,)
     d_path = pathlib.Path("d/")
     h_path = str(d_path / "h")
 
-    assert config.targets == ["."]
+    config.targets = ["."]
     with patch("wily.state.resolve_archiver", return_value=MockArchiver), patch(
         "wily.commands.build.resolve_operator", return_value=MockOperator
     ), patch("wily.commands.build.State", mock_state), patch(

--- a/test/unit/test_build_unit.py
+++ b/test/unit/test_build_unit.py
@@ -51,7 +51,7 @@ class MockArchiverCls(BaseArchiver):
 
 class MockOperatorCls(BaseOperator):
     name = "test"
-    data = {"C:\\home\\test1.py" if sys.platform == "win32" else "/home/test1.py": None}
+    data = {"\\home\\test1.py" if sys.platform == "win32" else "/home/test1.py": None}
 
     def __init__(self, *args, **kwargs):
         pass

--- a/test/unit/test_build_unit.py
+++ b/test/unit/test_build_unit.py
@@ -102,8 +102,8 @@ def test_build_targets():
     ):
         build.build(config, MockArchiver, _test_operators)  # type: ignore
     assert len(mock_starmap.mock_calls) == 6
-    assert mock_starmap.mock_calls[0].args[-1][-1][-1] == ["e", h_path, "f"]
-    assert mock_starmap.mock_calls[3].args[-1][-1][-1] == []
+    assert mock_starmap.call_args_list[0][0][1][-1][-1] == ["e", h_path, "f"]
+    assert mock_starmap.call_args_list[1][0][1][-1][-1] == []
 
     config.targets = [str(d_path)]
     mock_starmap.reset_mock()
@@ -114,8 +114,8 @@ def test_build_targets():
     ):
         build.build(config, MockArchiver, _test_operators)  # type: ignore
     assert len(mock_starmap.mock_calls) == 6
-    assert mock_starmap.mock_calls[0].args[-1][-1][-1] == [h_path]
-    assert mock_starmap.mock_calls[3].args[-1][-1][-1] == []
+    assert mock_starmap.call_args_list[0][0][1][-1][-1] == [h_path]
+    assert mock_starmap.call_args_list[1][0][1][-1][-1] == []
 
 
 def test_run_operator(config):

--- a/test/unit/test_build_unit.py
+++ b/test/unit/test_build_unit.py
@@ -73,6 +73,11 @@ def config():
 
 def test_build_simple(config):
     _test_operators = (MockOperator,)
+    # Remove drive from config path, as that breaks os.path.relpath on GitHub
+    # test runner because config path and test directory point to diffent drives
+    path = config.path
+    config.path = str(pathlib.Path().joinpath("/", *pathlib.Path(path).parts[1:]))
+
     with patch("wily.state.resolve_archiver", return_value=MockArchiver), patch(
         "wily.commands.build.resolve_operator", return_value=MockOperator
     ):

--- a/test/unit/test_build_unit.py
+++ b/test/unit/test_build_unit.py
@@ -74,7 +74,7 @@ def config():
 def test_build_simple(config):
     _test_operators = (MockOperator,)
     # Remove drive from config path, as that breaks os.path.relpath on GitHub
-    # test runner because config path and test directory point to diffent drives
+    # test runner because config path and test directory point to different drives
     path = config.path
     config.path = str(pathlib.Path().joinpath("/", *pathlib.Path(path).parts[1:]))
 

--- a/test/unit/test_build_unit.py
+++ b/test/unit/test_build_unit.py
@@ -122,5 +122,5 @@ def test_run_operator(config):
     rev = Revision("123", None, None, 1, "message", [], [], [], [], [])
     name, data = build.run_operator(MockOperator, rev, config, ["test1.py"])
     assert name == "mock"
-    path = "C:\\home\\test1.py" if sys.platform == "win32" else "/home/test1.py"
+    path = "\\home\\test1.py" if sys.platform == "win32" else "/home/test1.py"
     assert data == {os.path.relpath(path, config.path): None}


### PR DESCRIPTION
When building, wily creates lists of target files to scan based on added and modified files from the git repository. It's possible to pass a path to `wily build`, but it won't currently avoid scanning files outside of the path.

This PR makes wily only scan files that are children of the chosen path during build. This is an improvement for building in repositories that contains large files that aren't interesting to analyze. The behavior remains unchanged if no path is passed to `wily build`.

This addresses a TODO in build.py, adapting some commented out code:
https://github.com/tonybaloney/wily/blob/2590691d5d29a2872cc175bdb773b1dbf5fde202/src/wily/commands/build.py#L103