### PR TITLE
Fix wrapping of colored values

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,8 +54,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+    - run: python -m pip install --upgrade pip
     - run: pip install --user ruff
-    - run: ruff --format=github .
+    - run: ruff --output-format=github .
 
   pyright:
     runs-on: ubuntu-latest

--- a/src/wily/commands/diff.py
+++ b/src/wily/commands/diff.py
@@ -29,6 +29,8 @@ from wily.operators import (
 from wily.state import State
 
 # Monkeypatch tabulate to fix wrapping bug (https://github.com/astanin/python-tabulate/issues/307):
+if not hasattr(tabulate._CustomTextWrap, "original_handle_long_word"):  # type: ignore
+    tabulate._CustomTextWrap.original_handle_long_word = tabulate._CustomTextWrap._handle_long_word  # type: ignore
 tabulate._CustomTextWrap._handle_long_word = handle_long_word  # type: ignore
 
 

--- a/src/wily/commands/diff.py
+++ b/src/wily/commands/diff.py
@@ -17,7 +17,7 @@ from wily.archivers import resolve_archiver
 from wily.commands.build import run_operator
 from wily.config import DEFAULT_PATH
 from wily.config.types import WilyConfig
-from wily.helper import get_maxcolwidth, get_style
+from wily.helper import get_maxcolwidth, get_style, handle_long_word
 from wily.operators import (
     BAD_COLORS,
     GOOD_COLORS,
@@ -27,6 +27,9 @@ from wily.operators import (
     resolve_operator,
 )
 from wily.state import State
+
+# Monkeypatch tabulate to fix wrapping bug (https://github.com/astanin/python-tabulate/issues/307):
+tabulate._CustomTextWrap._handle_long_word = handle_long_word  # type: ignore
 
 
 def diff(

--- a/src/wily/commands/report.py
+++ b/src/wily/commands/report.py
@@ -13,11 +13,14 @@ import tabulate
 
 from wily import MAX_MESSAGE_WIDTH, format_date, format_revision, logger
 from wily.config.types import WilyConfig
-from wily.helper import get_maxcolwidth
+from wily.helper import get_maxcolwidth, handle_long_word
 from wily.helper.custom_enums import ReportFormat
 from wily.lang import _
 from wily.operators import MetricType, resolve_metric_as_tuple
 from wily.state import State
+
+# Monkeypatch tabulate to fix wrapping bug (https://github.com/astanin/python-tabulate/issues/307):
+tabulate._CustomTextWrap._handle_long_word = handle_long_word  # type: ignore
 
 ANSI_RED = 31
 ANSI_GREEN = 32

--- a/src/wily/commands/report.py
+++ b/src/wily/commands/report.py
@@ -20,6 +20,8 @@ from wily.operators import MetricType, resolve_metric_as_tuple
 from wily.state import State
 
 # Monkeypatch tabulate to fix wrapping bug (https://github.com/astanin/python-tabulate/issues/307):
+if not hasattr(tabulate._CustomTextWrap, "original_handle_long_word"):  # type: ignore
+    tabulate._CustomTextWrap.original_handle_long_word = tabulate._CustomTextWrap._handle_long_word  # type: ignore
 tabulate._CustomTextWrap._handle_long_word = handle_long_word  # type: ignore
 
 ANSI_RED = 31

--- a/src/wily/helper/__init__.py
+++ b/src/wily/helper/__init__.py
@@ -5,7 +5,7 @@ import pathlib
 import shutil
 import sys
 from functools import lru_cache
-from typing import Optional, Sized, Union
+from typing import List, Optional, Sized, Union
 
 import tabulate
 
@@ -63,7 +63,7 @@ ansi_codes = tabulate._ansi_codes  # type: ignore
 
 
 def handle_long_word(
-    self, reversed_chunks: list[str], cur_line: list[str], cur_len: int, width: int
+    self, reversed_chunks: List[str], cur_line: List[str], cur_len: int, width: int
 ):
     """
     Handle a chunk of text that is too long to fit in any line.

--- a/src/wily/helper/__init__.py
+++ b/src/wily/helper/__init__.py
@@ -7,6 +7,8 @@ import sys
 from functools import lru_cache
 from typing import Optional, Sized, Union
 
+import tabulate
+
 from wily.defaults import DEFAULT_GRID_STYLE
 
 logger = logging.getLogger(__name__)
@@ -54,3 +56,60 @@ def generate_cache_path(path: Union[pathlib.Path, str]) -> str:
     cache_path = str(HOME / ".wily" / sha)
     logger.debug("Cache path is %s", cache_path)
     return cache_path
+
+
+strip_ansi = tabulate._strip_ansi  # type: ignore
+ansi_codes = tabulate._ansi_codes  # type: ignore
+
+
+def handle_long_word(
+    self, reversed_chunks: list[str], cur_line: list[str], cur_len: int, width: int
+):
+    """
+    Handle a chunk of text that is too long to fit in any line.
+
+    Fixed version of tabulate._CustomTextWrap._handle_long_word that avoids a
+    wrapping bug (https://github.com/astanin/python-tabulate/issues/307) where
+    ANSI escape codes would be broken up in the middle.
+    """
+    # Figure out when indent is larger than the specified width, and make
+    # sure at least one character is stripped off on every pass
+    if width < 1:
+        space_left = 1
+    else:
+        space_left = width - cur_len
+
+    # If we're allowed to break long words, then do so: put as much
+    # of the next chunk onto the current line as will fit.
+    if self.break_long_words:
+        # Tabulate Custom: Build the string up piece-by-piece in order to
+        # take each character's width into account
+        chunk = reversed_chunks[-1]
+        i = 1
+        # Only count printable characters, so strip_ansi first, index later.
+        while len(strip_ansi(chunk)[:i]) <= space_left:
+            i = i + 1
+        # Consider escape codes when breaking words up
+        total_escape_len = 0
+        last_group = 0
+        if ansi_codes.search(chunk) is not None:
+            for group, _, _, _ in ansi_codes.findall(chunk):
+                escape_len = len(group)
+                if group in chunk[last_group : i + total_escape_len + escape_len - 1]:
+                    total_escape_len += escape_len
+                    found = ansi_codes.search(chunk[last_group:])
+                    last_group += found.end()
+        cur_line.append(chunk[: i + total_escape_len - 1])
+        reversed_chunks[-1] = chunk[i + total_escape_len - 1 :]
+
+    # Otherwise, we have to preserve the long word intact.  Only add
+    # it to the current line if there's nothing already there --
+    # that minimizes how much we violate the width constraint.
+    elif not cur_line:
+        cur_line.append(reversed_chunks.pop())
+
+    # If we're not allowed to break long words, and there's already
+    # text on the current line, do nothing.  Next time through the
+    # main loop of _wrap_chunks(), we'll wind up here again, but
+    # cur_len will be zero, so the next line will be entirely
+    # devoted to the long word that we can't handle right now.

--- a/test/unit/test_helper.py
+++ b/test/unit/test_helper.py
@@ -167,10 +167,10 @@ def test_handle_long_word():
         "\033[31mxtWrap\033[0m_with_",
         "colors",
     ]
-    wrapper = tabulate._CustomTextWrap(width=12)
+    wrapper = tabulate._CustomTextWrap(width=12)  # type: ignore
     result = wrapper.wrap(data)
     assert result != expected
     tabulate._CustomTextWrap._handle_long_word = handle_long_word  # type: ignore
-    wrapper = tabulate._CustomTextWrap(width=12)
+    wrapper = tabulate._CustomTextWrap(width=12)  # type: ignore
     result = wrapper.wrap(data)
     assert result == expected

--- a/test/unit/test_helper.py
+++ b/test/unit/test_helper.py
@@ -167,6 +167,9 @@ def test_handle_long_word():
         "\033[31mxtWrap\033[0m_with_",
         "colors",
     ]
+    if hasattr(tabulate._CustomTextWrap, "original_handle_long_word"):  # type: ignore
+        # We've already monkeypatched _CustomTextWrap, undo it.
+        tabulate._CustomTextWrap._handle_long_word = tabulate._CustomTextWrap.original_handle_long_word  # type: ignore
     wrapper = tabulate._CustomTextWrap(width=12)  # type: ignore
     result = wrapper.wrap(data)
     assert result != expected

--- a/test/unit/test_helper.py
+++ b/test/unit/test_helper.py
@@ -4,7 +4,7 @@ from unittest import mock
 import tabulate
 
 from wily.defaults import DEFAULT_GRID_STYLE
-from wily.helper import get_maxcolwidth, get_style
+from wily.helper import get_maxcolwidth, get_style, handle_long_word
 
 SHORT_DATA = [list("abcdefgh"), list("abcdefgh")]
 
@@ -156,3 +156,21 @@ def test_get_style_none():
     with mock.patch("sys.stdout", output):
         style = get_style()
     assert style == "fancy_grid"
+
+
+def test_handle_long_word():
+    data = "This_is_a_\033[31mtest_string_for_testing_TextWrap\033[0m_with_colors"
+    expected = [
+        "This_is_a_\033[31mte\033[0m",
+        "\033[31mst_string_fo\033[0m",
+        "\033[31mr_testing_Te\033[0m",
+        "\033[31mxtWrap\033[0m_with_",
+        "colors",
+    ]
+    wrapper = tabulate._CustomTextWrap(width=12)
+    result = wrapper.wrap(data)
+    assert result != expected
+    tabulate._CustomTextWrap._handle_long_word = handle_long_word  # type: ignore
+    wrapper = tabulate._CustomTextWrap(width=12)
+    result = wrapper.wrap(data)
+    assert result == expected


### PR DESCRIPTION
Sometimes tabulate will create [broken wrapping tables by wrapping in the middle of ANSI escape codes](https://github.com/astanin/python-tabulate/issues/307#issue-2079178117). A [fix has been proposed](https://github.com/astanin/python-tabulate/pull/308#issue-2081890566) at the tabulate repository, but the project seems to be dormant at the moment.

This PR uses the code from the fix to monkeypatch `tabulate._CustomTextWrap._handle_long_word` in `report()` and `diff()`, so we don't have the bug. A test is included.

Before patch:
```
├────────────┼─────────────┼───────────┼────────────┼──────────────┼────────────┼───────────────┼────────────┤
│ dbe9172    │ Add unit    │ devdanzin │ 2023-09-24 │ 14.9615      │ 74 (0)     │ 78.5874 ( 3381 (+1)  │
│            │ tests for   │           │            │ (0.0)        │            │ 31m-0.00851   │            │
│            │ some        │           │            │              │            │ 093)          │            │
│            │ commands    │           │            │              │            │               │            │
│            │ (#199)  *   │           │            │              │            │               │            │
│            │ Add uni     │           │            │              │            │               │            │
├────────────┼─────────────┼───────────┼────────────┼──────────────┼────────────┼───────────────┼────────────┤
│ d0ad384    │ Add some    │ devdanzin │ 2023-09-22 │ 14.9615 ( 74 (-1)    │ 78.5959       │ 3380 (-15) │
│            │ more typing │           │            │ 32m-0.03846  │            │ (-0.306704)   │            │
│            │ (#221)  *   │           │            │ 15)          │            │               │            │
│            │ Update      │           │            │              │            │               │            │
│            │ typing info │           │            │              │            │               │            │
├────────────┼─────────────┼───────────┼────────────┼──────────────┼────────────┼───────────────┼────────────┤
```
![broken_color_wrap](https://github.com/tonybaloney/wily/assets/74280297/3bd87961-c064-4895-86a6-eec4659250ce)

After patch:
```
├────────────┼─────────────┼───────────┼────────────┼──────────────┼────────────┼───────────────┼────────────┤
│ dbe9172    │ Add unit    │ devdanzin │ 2023-09-24 │ 14.9615      │ 74 (0)     │ 78.5874 (-0   │ 3381 (+1)  │
│            │ tests for   │           │            │ (0.0)        │            │ .00851093)    │            │
│            │ some        │           │            │              │            │               │            │
│            │ commands    │           │            │              │            │               │            │
│            │ (#199)  *   │           │            │              │            │               │            │
│            │ Add uni     │           │            │              │            │               │            │
├────────────┼─────────────┼───────────┼────────────┼──────────────┼────────────┼───────────────┼────────────┤
│ d0ad384    │ Add some    │ devdanzin │ 2023-09-22 │ 14.9615 (-0  │ 74 (-1)    │ 78.5959       │ 3380 (-15) │
│            │ more typing │           │            │ .0384615)    │            │ (-0.306704)   │            │
│            │ (#221)  *   │           │            │              │            │               │            │
│            │ Update      │           │            │              │            │               │            │
│            │ typing info │           │            │              │            │               │            │
├────────────┼─────────────┼───────────┼────────────┼──────────────┼────────────┼───────────────┼────────────┤
```
![fixed_color_wrap](https://github.com/tonybaloney/wily/assets/74280297/5094ddfc-ec0e-41ca-85fc-76868d92c369)
