### PR TITLE
Fix github actions example `Error: Resource not accessible by integration`

### DIFF
--- a/docs/source/ci.rst
+++ b/docs/source/ci.rst
@@ -87,6 +87,8 @@ When using Wily in a Github Workflows, you need to specify to the checkout step 
     evaluate-complexity:
       name: Evaluate Code complexity
       runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
 
       steps:
         - name: Checkout repository


### PR DESCRIPTION
Changes to default read-write permissions mean write must be explicitly enabled for new repos.

Using the current example as is will result in a `Error: Resource not accessible by integration` when attempting to write a comment.

https://github.com/marocchino/sticky-pull-request-comment/tree/main?tab=readme-ov-file#error-resource-not-accessible-by-integration