### PR TITLE
Add v1 to v2 migration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Wily uses git to go through each revision (commit) in a branch and run complexit
 
 ## Installation
 
-Wily can be installed via pip from Python 3.6 and above:
+Wily can be installed via pip from Python 3.10 and above:
 
 ```console
  $ pip install wily
@@ -86,7 +86,7 @@ repos:
 The first step to using `wily` is to build a wily cache with the statistics of your project. 
 
 ```default
-Usage: __main__.py build [OPTIONS] [TARGETS]...
+Usage: wily build [OPTIONS] [TARGETS]...
 
   Build the wily cache
 
@@ -94,6 +94,8 @@ Options:
   -n, --max-revisions INTEGER  The maximum number of historical commits to
                                archive
   -o, --operators TEXT         List of operators, separated by commas
+  -a, --archiver TEXT          Archiver to use, defaults to git if git repo,
+                               else filesystem
   --help                       Show this message and exit.
 ```
 
@@ -143,36 +145,31 @@ List the metrics available in the Wily operators. Each one of the metrics can be
 
 ```console
  $ wily list-metrics
-mccabe operator:
-No metrics available
-raw operator:
-╒═════════════════╤══════════════════════╤═══════════════╤══════════════════════════╕
-│                 │ Name                 │ Description   │ Type                     │
-╞═════════════════╪══════════════════════╪═══════════════╪══════════════════════════╡
-│ loc             │ Lines of Code        │ <class 'int'> │ MetricType.Informational │
-├─────────────────┼──────────────────────┼───────────────┼──────────────────────────┤
-│ lloc            │ L Lines of Code      │ <class 'int'> │ MetricType.Informational │
-├─────────────────┼──────────────────────┼───────────────┼──────────────────────────┤
-│ sloc            │ S Lines of Code      │ <class 'int'> │ MetricType.Informational │
-├─────────────────┼──────────────────────┼───────────────┼──────────────────────────┤
-│ comments        │ Multi-line comments  │ <class 'int'> │ MetricType.Informational │
-├─────────────────┼──────────────────────┼───────────────┼──────────────────────────┤
-│ multi           │ Multi lines          │ <class 'int'> │ MetricType.Informational │
-├─────────────────┼──────────────────────┼───────────────┼──────────────────────────┤
-│ blank           │ blank lines          │ <class 'int'> │ MetricType.Informational │
-├─────────────────┼──────────────────────┼───────────────┼──────────────────────────┤
-│ single_comments │ Single comment lines │ <class 'int'> │ MetricType.Informational │
-╘═════════════════╧══════════════════════╧═══════════════╧══════════════════════════╛
 cyclomatic operator:
-No metrics available
+  complexity  Cyclomatic Complexity (float, AimLow)
 maintainability operator:
-╒══════╤═════════════════════════╤═════════════════╤══════════════════════════╕
-│      │ Name                    │ Description     │ Type                     │
-╞══════╪═════════════════════════╪═════════════════╪══════════════════════════╡
-│ rank │ Maintainability Ranking │ <class 'str'>   │ MetricType.Informational │
-├──────┼─────────────────────────┼─────────────────┼──────────────────────────┤
-│ mi   │ Maintainability Index   │ <class 'float'> │ MetricType.AimLow        │
-╘══════╧═════════════════════════╧═════════════════╧══════════════════════════╛
+  rank        Maintainability Ranking (str, Informational)
+  mi          Maintainability Index (float, AimHigh)
+raw operator:
+  loc             Lines of Code (int, Informational)
+  lloc            L Lines of Code (int, AimLow)
+  sloc            S Lines of Code (int, AimLow)
+  comments        Multi-line comments (int, AimHigh)
+  multi           Multi lines (int, Informational)
+  blank           blank lines (int, Informational)
+  single_comments Single comment lines (int, Informational)
+halstead operator:
+  h1          Unique Operators (int, AimLow)
+  h2          Unique Operands (int, AimLow)
+  N1          Number of Operators (int, AimLow)
+  N2          Number of Operands (int, AimLow)
+  vocabulary  Unique vocabulary (int, AimLow)
+  length      Length of application (int, AimLow)
+  volume      Code volume (float, AimLow)
+  difficulty  Difficulty (float, AimLow)
+  effort      Effort (float, AimLow)
+cognitive operator:
+  cognitive_complexity  Cognitive Complexity (float, AimLow)
 ```
 
 ## Configuration
@@ -189,6 +186,12 @@ archiver = git
 path = /path/to/target
 # max revisions to archive, defaults to 50
 max_revisions = 20
+# override the default cache path
+cache_path = /path/to/cache
+# enable/disable scanning of Jupyter notebooks, defaults to true
+include_ipynb = true
+# enable/disable reporting on individual notebook cells, defaults to true
+ipynb_cells = true
 ```
 
 You can also override the path to the configuration with the `--config` flag on the command-line.
@@ -197,7 +200,7 @@ You can also override the path to the configuration with the `--config` flag on 
 
 Wily will detect and scan all Python code in .ipynb files automatically. 
 
-You can disable this behaviour if you require by setting `ipynb_support = false` in the configuration.
+You can disable this behaviour if you require by setting `include_ipynb = false` in the configuration.
 You can also disable the behaviour of reporting on individual cells by setting `ipynb_cells = false`.
 
 # Credits

--- a/docs/source/ci.rst
+++ b/docs/source/ci.rst
@@ -90,28 +90,25 @@ When using Wily in a Github Workflows, you need to specify to the checkout step 
 
       steps:
         - name: Checkout repository
-          uses: actions/checkout@v2
+          uses: actions/checkout@v4
           with:
             fetch-depth: 0
             ref: ${{ github.event.pull_request.head.ref }}
         - name: Set up Python
-          uses: actions/setup-python@v2
+          uses: actions/setup-python@v4
           with:
-            python-version: 3.10.0
+            python-version: "3.12"
         - name: Install Wily
-          run: pip install wily==1.20.0
+          run: pip install wily
         - name: Build cache and diff
           id: wily
           run: |
             wily build my_package/ tests/
             DIFF=$(wily diff my_package/ tests/ --no-detail -r origin/${{ github.event.pull_request.base.ref }})
             echo "$DIFF"
-
-            # Build multine output
-            DIFF="${DIFF//'%'/'%25'}"
-            DIFF="${DIFF//$'\n'/'%0A'}"
-            DIFF="${DIFF//$'\r'/'%0D'}"
-            echo "::set-output name=diff::$DIFF"
+            echo "diff<<EOF" >> "$GITHUB_OUTPUT"
+            echo "$DIFF" >> "$GITHUB_OUTPUT"
+            echo "EOF" >> "$GITHUB_OUTPUT"
         - name: Find current PR
           uses: jwalton/gh-find-current-pr@v1
           id: findPr

--- a/docs/source/commands/build.rst
+++ b/docs/source/commands/build.rst
@@ -34,7 +34,7 @@ You can override the maximum number of commits recursed by using the ``-n`` or `
 
    $ wily build src/ test/ -n 100
 
-By default, wily will compile the cyclomatic complexity, cognitive complexity, maintainability, halstead and raw metrics. If you only want a subset of those, you can specify with comma-separate ``--operator`` or ``-o`` flag
+By default, wily will compile the cyclomatic complexity, cognitive complexity, maintainability, halstead and raw metrics. If you only want a subset of those, you can specify with comma-separated ``--operators`` or ``-o`` flag
 
 .. code-block:: none
 

--- a/docs/source/commands/graph.rst
+++ b/docs/source/commands/graph.rst
@@ -19,7 +19,7 @@ You can provide a second metric which will be used to control the size of the bu
 
 .. code-block:: none
 
-   $ wily graph example.py loc,complexity
+   $ wily graph example.py -m loc,complexity
 
 .. image:: ../_static/two_metric_graph.png
    :align: center
@@ -43,28 +43,28 @@ If one or more of the provided paths is a directory, you can use the ``--aggrega
 
 .. code-block:: none
 
-   $ wily tests/ -m loc --aggregate
+   $ wily graph tests/ -m loc --aggregate
 
 By default, ``wily graph`` will only plot revisions where metric values have changed. To show all revisions, use the ``--all`` option.
 
 .. code-block:: none
 
-   $ wily tests/ -m loc --all
+   $ wily graph tests/ -m loc --all
 
 By default, ``wily graph`` will create a file, ``wily-report.html`` in the current directory and open it using the browser configured in the $BROWSER environment variable (the default on the OS).
 To save the output to a specific HTML file and not open it, provide the ``-o`` flag and the name of the output file.
 
 .. code-block:: none
 
-   $ wily report example.py -m loc -o example.html
+   $ wily graph example.py -m loc -o example.html
 
 By default, ``wily graph`` will create an HTML file containing all the JS necessary to render the graph.
-To create a standalone plotly.min.js file in the same directory as the HTML file instead, pass the ``--shared-js`´ option.
-To point the HTML file to a CDN hosted plotly.min.js instead, pass the ``--cdn-js`´ option.
+To create a standalone plotly.min.js file in the same directory as the HTML file instead, pass the ``--shared-js`` option.
+To point the HTML file to a CDN hosted plotly.min.js instead, pass the ``--cdn-js`` option.
 
 .. code-block:: none
 
-   $ wily report example.py -m loc --shared=js
+   $ wily graph example.py -m loc --shared-js
 
 
 Command Line Usage

--- a/docs/source/commands/rank.rst
+++ b/docs/source/commands/rank.rst
@@ -35,11 +35,7 @@ Wily rank will show the last revision by default. If you want to show a specific
 
   $ wily rank src/ --revision HEAD^2
 
-Wily rank will exit with 0 by default if no error occurs. However, you can set a custom threshold. If the total value is below the specified threshold,
-the rank command will return a non-zero exit code.
-
-.. code-block:: none
-  $ wily rank --threshold=80
+Wily rank will exit with 0 by default if no error occurs.
 
 Command Line Usage
 ------------------

--- a/docs/source/commands/report.rst
+++ b/docs/source/commands/report.rst
@@ -15,9 +15,7 @@ To show a report, simply give the name or path to the file you want to report on
 
   $ wily report example.py
 
-By default, wily will show the default metrics (typically Lines-of-code, cyclomatic complexity and maintainability index).
-
-To change the metrics, provide the metric names (run ``wily list-metrics`` for a list) as arguments.
+By default, wily will show all available metrics. You can specify which metrics to display by providing metric names as arguments (run ``wily list-metrics`` for a list).
 
 .. code-block:: none
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -21,6 +21,7 @@ Wily uses git to go through each revision (commit) in a branch and run complexit
    :maxdepth: 1
    :caption: Contents:
 
+   migration_v2
    ci
    commands/build
    commands/diff

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -79,7 +79,7 @@ You can display any of the metrics in a HTML graph by running the graph command 
 
 .. code-block:: console
 
-   $ wily graph wily/__main__.py loc
+   $ wily graph wily/__main__.py -m loc
 
 .. image:: _static/single_metric_graph.png
    :align: center

--- a/docs/source/migration_v2.rst
+++ b/docs/source/migration_v2.rst
@@ -1,0 +1,268 @@
+============================
+Migrating from v1 to v2
+============================
+
+Wily v2 is a major rewrite. The analysis backend has been replaced with a Rust native extension, the storage format has changed from JSON to Parquet, and several operators have been renamed or replaced. This guide covers everything you need to know to upgrade.
+
+.. contents:: On this page
+   :local:
+   :depth: 2
+
+Requirements
+------------
+
+- **Python 3.10+** is required. Wily v1 supported Python 3.6+.
+- **Rust toolchain** is only needed if building from source. Pre-built wheels are available for Linux, macOS, and Windows (x86_64 and aarch64).
+
+Rebuilding the cache
+--------------------
+
+The v1 cache (JSON files under ``~/.wily/``) is **not compatible** with v2. You must rebuild:
+
+.. code-block:: console
+
+   $ wily clean -y
+   $ wily build src/
+
+This will delete the old cache and create a new one using the Parquet storage format. The new cache is significantly faster for large codebases thanks to columnar storage and parallel analysis.
+
+.. note::
+
+   If you use ``--cache`` to specify a custom cache path, make sure to clean and rebuild that location as well.
+
+Operator and metric changes
+---------------------------
+
+Removed: ``mccabe``
+~~~~~~~~~~~~~~~~~~~~
+
+The ``mccabe`` operator from v1 (which used the ``mccabe`` Python package) has been **removed**. Its functionality is replaced by the ``cyclomatic`` operator, which now uses Ruff's AST parser implemented in Rust.
+
+If you referenced ``mccabe`` in your configuration or scripts, change it to ``cyclomatic``:
+
+.. code-block:: console
+
+   # v1
+   $ wily build src/ -o raw,mccabe,maintainability
+
+   # v2
+   $ wily build src/ -o raw,cyclomatic,maintainability
+
+The metric name remains ``complexity`` (accessed as ``cyclomatic.complexity``), so ``wily report`` and ``wily graph`` commands using that metric name will continue to work.
+
+New: ``cognitive``
+~~~~~~~~~~~~~~~~~~
+
+v2 adds a new ``cognitive`` operator that measures cognitive complexity — how hard code is to *understand*, as opposed to cyclomatic complexity which measures structural/branching complexity. Based on the SonarSource "Cognitive Complexity" paper by G. Ann Campbell (2017).
+
+.. code-block:: console
+
+   $ wily build src/ -o raw,cyclomatic,cognitive,maintainability
+   $ wily report src/module.py cognitive.cognitive_complexity
+
+Default operators
+~~~~~~~~~~~~~~~~~
+
+In v2, the default operator set is: ``cyclomatic``, ``maintainability``, ``raw``, ``halstead``, and ``cognitive``. In v1, the defaults were: ``raw``, ``maintainability``, ``cyclomatic``, and ``halstead``.
+
+The main difference is that ``cognitive`` is now included by default.
+
+Metric name reference
+~~~~~~~~~~~~~~~~~~~~~
+
+All metrics from v1 are still available in v2 under the same names. Here is the complete list:
+
+.. list-table:: Metrics
+   :header-rows: 1
+   :widths: 25 35 15
+
+   * - Metric key
+     - Description
+     - Operator
+   * - ``raw.loc``
+     - Lines of Code
+     - raw
+   * - ``raw.lloc``
+     - Logical Lines of Code
+     - raw
+   * - ``raw.sloc``
+     - Source Lines of Code
+     - raw
+   * - ``raw.comments``
+     - Multi-line comments
+     - raw
+   * - ``raw.multi``
+     - Multi lines
+     - raw
+   * - ``raw.blank``
+     - Blank lines
+     - raw
+   * - ``raw.single_comments``
+     - Single comment lines
+     - raw
+   * - ``cyclomatic.complexity``
+     - Cyclomatic Complexity
+     - cyclomatic
+   * - ``halstead.h1``
+     - Unique Operators
+     - halstead
+   * - ``halstead.h2``
+     - Unique Operands
+     - halstead
+   * - ``halstead.N1``
+     - Number of Operators
+     - halstead
+   * - ``halstead.N2``
+     - Number of Operands
+     - halstead
+   * - ``halstead.vocabulary``
+     - Unique vocabulary (h1 + h2)
+     - halstead
+   * - ``halstead.length``
+     - Length of application
+     - halstead
+   * - ``halstead.volume``
+     - Code volume
+     - halstead
+   * - ``halstead.difficulty``
+     - Difficulty
+     - halstead
+   * - ``halstead.effort``
+     - Effort
+     - halstead
+   * - ``maintainability.mi``
+     - Maintainability Index
+     - maintainability
+   * - ``maintainability.rank``
+     - Maintainability Ranking (A/B/C)
+     - maintainability
+   * - ``cognitive.cognitive_complexity``
+     - Cognitive Complexity *(new in v2)*
+     - cognitive
+
+CLI changes
+-----------
+
+The CLI commands are largely the same between v1 and v2. The main differences are:
+
+New options on existing commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Several commands gained new formatting options in v2:
+
+- ``--wrap/--no-wrap``: Control whether output wraps to terminal width (available on ``index``, ``rank``, ``report``, ``diff``, ``list-metrics``)
+- ``--table-style``: Choose a Rich table border style such as ``ROUNDED``, ``ASCII``, ``SIMPLE``, ``MINIMAL``, or ``MARKDOWN`` (available on the same commands)
+- ``--json/--no-json``: Output ``diff`` results in JSON format
+
+Output formatting
+~~~~~~~~~~~~~~~~~
+
+- v1 used ``tabulate`` for console tables. v2 uses **Rich**, which provides better terminal rendering with color support and configurable table styles.
+- HTML reports continue to work with the ``-f HTML`` option on ``wily report``.
+
+Removed dependencies
+--------------------
+
+v2 removes several Python dependencies that were used in v1 for metric computation:
+
+.. list-table:: Dependency changes
+   :header-rows: 1
+   :widths: 30 30
+
+   * - v1 (Python)
+     - v2 (Rust backend)
+   * - ``radon`` (cyclomatic, raw, halstead, MI)
+     - Built-in Rust implementation using ``ruff_python_parser``
+   * - ``mccabe`` (McCabe complexity)
+     - Removed (replaced by ``cyclomatic`` operator)
+   * - ``tabulate`` (console output)
+     - Replaced by ``rich``
+
+The remaining Python dependencies in v2 are: ``gitpython``, ``click``, ``nbformat``, ``plotly``, and ``rich``.
+
+Storage format
+--------------
+
+.. list-table:: Storage comparison
+   :header-rows: 1
+   :widths: 20 40 40
+
+   * -
+     - v1
+     - v2
+   * - Format
+     - JSON files (one per revision per operator)
+     - Single Parquet file per archiver
+   * - Location
+     - ``~/.wily/<hash>/<archiver>/<revision>.json``
+     - ``~/.wily/<hash>/<archiver>/metrics.parquet``
+   * - Schema
+     - Nested JSON (operator → path → metrics)
+     - Flat columnar (one row per file per revision)
+   * - Performance
+     - Slower on large codebases
+     - Significantly faster (columnar reads + parallel writes)
+
+The Parquet schema stores metadata columns (``revision``, ``date``, ``author``, ``message``, ``path``, ``path_type``) alongside all metric values as top-level columns.
+
+Row types by ``path_type``:
+
+- ``"file"`` — metrics for an individual Python file
+- ``"directory"`` — aggregated metrics for a directory
+- ``"root"`` — aggregated metrics for the entire project (path is ``""``)
+- ``"function"`` / ``"class"`` — detailed object-level metrics (path format: ``"file.py:object_name"``)
+
+Configuration
+-------------
+
+Wily v2 continues to read configuration from ``wily.cfg`` files. The configuration format is unchanged.
+
+The ``--path``, ``--cache``, ``--debug``, and ``--config`` global options work the same as in v1.
+
+Pre-commit hook
+---------------
+
+The pre-commit hook configuration is unchanged:
+
+.. code-block:: yaml
+
+    repos:
+    -   repo: local
+        hooks:
+        -   id: wily
+            name: wily
+            entry: wily diff
+            verbose: true
+            language: python
+            additional_dependencies: [wily]
+
+CI/CD usage
+-----------
+
+If you use wily in CI/CD pipelines:
+
+1. **Update your Python version** to 3.10+ if not already.
+2. **Remove ``mccabe`` references** from any operator lists.
+3. **Rebuild your cache** — if you cache the ``~/.wily/`` directory between CI runs, delete it and rebuild. The v1 JSON cache is not compatible.
+4. **Update any metric parsing scripts** — if you parse wily's output programmatically, note that the console output now uses Rich formatting. Use ``wily diff --json`` for machine-readable output.
+
+Performance improvements
+------------------------
+
+v2 brings significant performance improvements:
+
+- **Parallel file analysis**: Files are analyzed in parallel using Rayon (Rust). Build times are substantially faster on multi-core machines.
+- **Rust-native parsing**: Python AST parsing uses ``ruff_python_parser`` (from the Ruff project), which is much faster than the Python-based ``radon`` and ``mccabe`` packages.
+- **Columnar storage**: Parquet format enables faster reads for report and graph operations, especially on large indexes.
+- **Reduced Python overhead**: The hot path (parsing, metric computation, storage I/O) runs entirely in Rust.
+
+Quick migration checklist
+-------------------------
+
+1. ✅ Ensure Python 3.10+ is installed
+2. ✅ Install wily v2: ``pip install wily``
+3. ✅ Delete old cache: ``wily clean -y``
+4. ✅ Replace ``mccabe`` with ``cyclomatic`` in any config or scripts
+5. ✅ Rebuild the index: ``wily build src/``
+6. ✅ Verify with ``wily report`` or ``wily index``
+7. ✅ Optionally try the new ``cognitive`` operator


### PR DESCRIPTION
Adds a comprehensive migration guide for users upgrading from wily v1 to v2, covering:

- **Cache rebuild**: v1 JSON cache is incompatible; users must run \wily clean\ and \wily build\
- **Operator changes**: \mccabe\ removed (replaced by \cyclomatic\), new \cognitive\ operator added
- **Metric reference table**: Complete list of all metrics with their operator and key
- **CLI changes**: New \--wrap\, \--table-style\, \--json\ options; Rich replaces tabulate
- **Dependency changes**: radon, mccabe, tabulate removed; Rust backend handles computation
- **Storage format**: JSON → Parquet comparison table with schema details
- **Performance improvements**: Parallel analysis, Rust-native parsing, columnar storage
- **CI/CD guidance**: What to update in pipelines
- **Quick migration checklist**

The guide is added as \docs/source/migration_v2.rst\ and linked as the first item in the docs table of contents.

Closes #248