### PR TITLE
Add dedicated release workflow with PyPI trusted publishers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,89 +1,17 @@
 ---
-name: CI
+name: Release
+
 on:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
-  workflow_dispatch: {}
+  release:
+    types: [published]
 
 env:
   COLUMNS: 150
 
 jobs:
-  test:
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - ubuntu-latest
-          - windows-latest
-          - macos-latest
-        python-version:
-          - '3.10'
-          - '3.11'
-          - '3.12'
-          - '3.13'
-          - '3.14'
-    runs-on: "${{ matrix.os }}"
-    continue-on-error: false
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-      - name: Cache Rust
-        uses: Swatinem/rust-cache@v2
-      - name: Install uv
-        uses: astral-sh/setup-uv@v2
-      - name: Sync project environment
-        run: uv sync --all-groups --python "${{ matrix.python-version }}"
-      - name: test
-        run: uv run pytest
-      - name: upload coverage to codecov
-        uses: codecov/codecov-action@v3
-        with:
-          # TODO(tonybaloney): move token to `secrets.CODECOV_TOKEN`
-          token: 48f9ff3a-6358-4607-aa5d-9cb7cada539c
-          files: .tests-reports/coverage.xml
-          fail_ci_if_error: true
-
-  ruff:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v2
-      - run: uv tool run ruff check .
-
-  # Rust linting
-  clippy:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy
-      - name: Cache Rust
-        uses: Swatinem/rust-cache@v2
-      - name: Run clippy
-        run: cargo clippy --manifest-path backend/Cargo.toml -- -D warnings
-
-  rustfmt:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt
-      - name: Check formatting
-        run: cargo fmt --manifest-path backend/Cargo.toml --check
-
-  # Build validation — ensures wheels and sdist build correctly
+  # Build source distribution
   build-sdist:
-    name: build sdist
+    name: Build sdist
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -100,31 +28,27 @@ jobs:
           name: pypi_files_sdist
           path: dist
 
-  build:
-    name: build on ${{ matrix.os }} (${{ matrix.target }})
+  # Build wheels for all supported platforms
+  build-wheels:
+    name: Build wheels on ${{ matrix.os }} (${{ matrix.target }})
     strategy:
       fail-fast: false
       matrix:
         include:
-          # Linux x86_64
           - os: linux
             target: x86_64
             runs-on: ubuntu-latest
             manylinux: auto
-          # Linux aarch64
           - os: linux
             target: aarch64
             runs-on: ubuntu-latest
             manylinux: auto
-          # macOS aarch64 (Apple Silicon)
           - os: macos
             target: aarch64
             runs-on: macos-latest
-          # Windows x86_64
           - os: windows
             target: x86_64
             runs-on: windows-latest
-          # Windows aarch64
           - os: windows
             target: aarch64
             python-architecture: arm64
@@ -172,3 +96,42 @@ jobs:
         with:
           name: pypi_files_${{ matrix.os }}_${{ matrix.target }}
           path: dist
+
+  # Publish to PyPI and attach assets to GitHub Release
+  publish:
+    name: Publish to PyPI
+    needs: [build-sdist, build-wheels]
+    runs-on: ubuntu-latest
+    environment:
+      name: release
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: pypi_files_*
+          merge-multiple: true
+          path: dist
+
+      - name: List dist files
+        run: |
+          ls -lh dist/
+          echo "Total files: $(ls dist | wc -l)"
+
+      - name: Verify wheel integrity
+        run: for whl in dist/*.whl; do unzip -qt "$whl"; done
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v2
+
+      - name: Publish to PyPI
+        run: uv publish --trusted-publishing always
+
+      - name: Upload assets to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*


### PR DESCRIPTION
## Summary

Separates the release pipeline from CI into a dedicated workflow triggered by GitHub Releases.

## Changes

### New: .github/workflows/release.yml
- **Trigger**: release published event - runs when a GitHub Release is created/published
- **Builds**: sdist + wheels for all platforms (Linux x86_64/aarch64, macOS aarch64, Windows x86_64/aarch64) for Python 3.10-3.14
- **Validation**: twine check --strict on all wheels, zip integrity verification
- **Publish**: uv publish --trusted-publishing always (PyPI OIDC trusted publishers)
- **Assets**: All dist files attached to the GitHub Release
- Requires a release environment with id-token: write permission

### Updated: .github/workflows/ci.yml
- Removed the inline release job (publishing now handled by release.yml)
- Removed v2 branch and tag triggers (v2 is merged into master)
- Kept build validation jobs (sdist + wheel builds + twine check) so packaging issues are caught in CI before release

## Release workflow

1. Push commits to master, CI validates tests + lints + builds
2. Create a GitHub Release (tag it e.g. v2.0.0 or v2.0.0a1)
3. Release workflow builds all wheels, publishes to PyPI, attaches assets to the release

## Notes

- PyPI trusted publisher must be configured on pypi.org for tonybaloney/wily with workflow release.yml and environment release
- The release GitHub environment should be configured with any required reviewers/protection rules
