### PR TITLE
Fix: Include LICENSE in sdist for PyPI upload

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ manifest-path = "backend/Cargo.toml"
 module-name = "wily.backend"
 python-source = "src"
 features = ["pyo3/generate-import-lib"]
+include = ["LICENSE"]
 
 [tool.uv]
 package = true


### PR DESCRIPTION
PyPI rejected the release upload with:

> License-File LICENSE does not exist in distribution file wily-2.0.0a1.tar.gz

Maturin auto-detects the LICENSE file for wheel metadata but wasn't including it in the sdist tarball. Adding `LICENSE` to `[tool.maturin] include` fixes it.

Verified locally - LICENSE now appears in the built sdist.