### PR TITLE
Single-source versioning: derive Python version from Cargo.toml

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,10 +11,58 @@ Please note we have a code of conduct, please follow it in all your interactions
    build.
 2. Update the README.md with details of changes to the interface, this includes new environment 
    variables, exposed ports, useful file locations and container parameters.
-3. Increase the version numbers in any examples files and the README.md to the new version that this
-   Pull Request would represent. The versioning scheme we use is [SemVer](http://semver.org/).
-4. You may merge the Pull Request in once you have the sign-off of two other developers, or if you 
+3. You may merge the Pull Request in once you have the sign-off of two other developers, or if you 
    do not have permission to do that, you may request the second reviewer to merge it for you.
+
+## Development Setup
+
+```console
+$ uv sync --all-groups
+$ maturin develop
+```
+
+## Releasing a New Version
+
+The version is defined in a single place: `backend/Cargo.toml`. The Python package version is derived automatically via maturin at build time and read at runtime using `importlib.metadata`.
+
+### Prerequisites
+
+Install [cargo-release](https://github.com/crate-ci/cargo-release):
+
+```console
+$ cargo install cargo-release
+```
+
+### Cutting a release
+
+1. **Bump the version** using `cargo-release`:
+
+   ```console
+   # For a patch release (e.g., 2.0.1 -> 2.0.2):
+   $ cargo release patch --manifest-path backend/Cargo.toml --execute
+
+   # For a minor release (e.g., 2.0.x -> 2.1.0):
+   $ cargo release minor --manifest-path backend/Cargo.toml --execute
+
+   # For a major release (e.g., 2.x.x -> 3.0.0):
+   $ cargo release major --manifest-path backend/Cargo.toml --execute
+
+   # For a pre-release (e.g., 2.0.0-alpha.2 -> 2.0.0-alpha.3):
+   $ cargo release alpha --manifest-path backend/Cargo.toml --execute
+   ```
+
+   This will:
+   - Update the version in `backend/Cargo.toml`
+   - Create a commit: `chore: release v<version>`
+   - Create a git tag: `v<version>`
+
+2. **Review** the commit and tag, then **push**:
+
+   ```console
+   $ git push && git push --tags
+   ```
+
+3. **Create a GitHub Release** from the tag. The release workflow will automatically build all wheels and publish to PyPI.
 
 ## Code of Conduct
 

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wily_backend"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 edition = "2021"
 
 [lib]

--- a/release.toml
+++ b/release.toml
@@ -1,0 +1,14 @@
+# cargo-release configuration
+# Install: cargo install cargo-release
+# Usage:   cargo release patch|minor|major|alpha|rc --execute
+#
+# This bumps the version in backend/Cargo.toml, commits, and creates a git tag.
+# The Python package version is derived automatically via maturin + importlib.metadata.
+
+[workspace]
+sign-tag = false
+tag-name = "v{{version}}"
+tag-message = "Release v{{version}}"
+pre-release-commit-message = "chore: release v{{version}}"
+publish = false
+push = false

--- a/src/wily/__init__.py
+++ b/src/wily/__init__.py
@@ -40,10 +40,11 @@ A Python application for tracking, reporting on timing and complexity in tests a
 import datetime
 import logging
 import tempfile
+from importlib.metadata import version
 
 from rich.logging import RichHandler
 
-__version__ = "2.0.0a2"
+__version__ = version("wily")
 
 _, WILY_LOG_NAME = tempfile.mkstemp(suffix="wily_log")
 


### PR DESCRIPTION
## Summary

Makes Cargo.toml the single source of truth for the version number, replacing the manually-maintained duplicate in __init__.py.

## Problem

Releasing required editing the version in two places with different formats:
- `backend/Cargo.toml`: `version = "2.0.0-alpha.1"` (Rust semver)
- `src/wily/__init__.py`: `__version__ = "2.0.0a1"` (PEP 440)

These were already out of sync (Cargo had alpha.1, Python had a2).

## Solution

### 1. importlib.metadata (no more hardcoded version)

`__init__.py` now reads the version from installed package metadata:

`python
from importlib.metadata import version
__version__ = version("wily")
`

Maturin already populates this from `Cargo.toml` and handles the semver-to-PEP440 conversion automatically (e.g., `2.0.0-alpha.2` becomes `2.0.0a2`).

### 2. cargo-release for version bumps

Added `release.toml` configuring cargo-release as the local tool for cutting releases:

`console
cargo release patch --manifest-path backend/Cargo.toml --execute
`

This bumps Cargo.toml, creates a commit, and creates a git tag. No shell scripts in CI, no security concerns.

### 3. Documented release process

Updated `CONTRIBUTING.md` with development setup and step-by-step release instructions.

## Verification

- All 148 tests pass
- `uv run python -c "from wily import __version__; print(__version__)"` correctly outputs `2.0.0a2`
