### PR TITLE
Fix wily rank to reconstruct full project state at latest revision (#262)

### DIFF
--- a/src/wily/commands/rank.py
+++ b/src/wily/commands/rank.py
@@ -99,15 +99,30 @@ def rank(
             format_date(target_revision_date),
         )
 
-        # Build lookup of metrics for target revision: {path: metric_value}
+        # Build lookup of metrics for the target revision: {path: metric_value}.
+        # Storage is delta-based (a full "seed" revision plus only the files that
+        # changed in each later revision), so the target revision on its own only
+        # contains the files touched in that single commit. To rank the full state
+        # of the project we reconstruct each file's value from the most recent row
+        # at or before the target revision's date.
         revision_data: dict[str, float | int | str] = {}
+        latest_date: dict[str, int] = {}
         for row in index:
-            if row["revision"] == target_revision_key:
-                file_path = row["path"]
-                # Get the metric value using just the metric name (not operator.metric)
-                metric_value = row.get(resolved_metric.name)
-                if metric_value is not None:
-                    revision_data[file_path] = metric_value
+            # Only rank file-level rows (skip directory/root aggregates and
+            # function/class detail rows, which otherwise pollute the table).
+            if row.get("path_type") != "file":
+                continue
+            row_date = row.get("revision_date", 0)
+            if row_date > target_revision_date:
+                continue
+            # Get the metric value using just the metric name (not operator.metric)
+            metric_value = row.get(resolved_metric.name)
+            if metric_value is None:
+                continue
+            file_path = row["path"]
+            if file_path not in latest_date or row_date >= latest_date[file_path]:
+                latest_date[file_path] = row_date
+                revision_data[file_path] = metric_value
 
         # Filter to requested path if specified
         if path is not None:

--- a/test/integration/test_rank.py
+++ b/test/integration/test_rank.py
@@ -1,8 +1,74 @@
+import pathlib
+
+import pytest
 from click.testing import CliRunner
 from git.repo.base import Repo
 from git.util import Actor
 
 import wily.__main__ as main
+
+
+@pytest.fixture
+def multifile_builddir(tmpdir):
+    """
+    A wily cache for a repo where one file is only present in the seed revision.
+
+    ``src/stable.py`` is added in the first (seed) commit and never touched
+    again, while ``src/churn.py`` is modified in a later commit. This exercises
+    the delta-based storage: the latest revision only contains ``churn.py``.
+    """
+    repo = Repo.init(path=tmpdir)
+    tmppath = pathlib.Path(tmpdir)
+    (tmppath / "src").mkdir()
+    stable = tmppath / "src" / "stable.py"
+    churn = tmppath / "src" / "churn.py"
+
+    author = Actor("An author", "author@example.com")
+    committer = Actor("A committer", "committer@example.com")
+
+    stable.write_text("def stable():\n    return 1\n")
+    churn.write_text("def churn():\n    return 1\n")
+    repo.index.add([str(stable), str(churn)])
+    repo.index.commit(
+        "seed",
+        author=author,
+        committer=committer,
+        author_date="Thu, 07 Apr 2019 22:13:13 +0200",
+        commit_date="Thu, 07 Apr 2019 22:13:13 +0200",
+    )
+
+    # Only modify churn.py in the second (latest) revision.
+    churn.write_text("def churn():\n    a = 1\n    if a:\n        return a\n    return 0\n")
+    repo.index.add([str(churn)])
+    repo.index.commit(
+        "change churn",
+        author=author,
+        committer=committer,
+        author_date="Mon, 10 Apr 2019 22:13:13 +0200",
+        commit_date="Mon, 10 Apr 2019 22:13:13 +0200",
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(main.cli, ["--debug", "--path", tmpdir, "build", str(tmppath / "src")])
+    assert result.exit_code == 0, result.stdout
+
+    yield tmpdir
+
+    runner.invoke(main.cli, ["--path", tmpdir, "clean", "-y"])
+    repo.close()
+
+
+def test_rank_latest_includes_unchanged_files(multifile_builddir):
+    """Rank at the latest revision must include files unchanged since the seed (#262)."""
+    runner = CliRunner()
+    result = runner.invoke(
+        main.cli, ["--path", multifile_builddir, "rank", "src/", "raw.loc", "--no-wrap"]
+    )
+    assert result.exit_code == 0, result.stdout
+    # churn.py changed in the last commit; stable.py only exists in the seed.
+    # Both must appear when ranking the latest revision.
+    assert "churn.py" in result.stdout, result.stdout
+    assert "stable.py" in result.stdout, result.stdout
 
 
 def test_rank_no_cache(tmpdir):


### PR DESCRIPTION
Fixes #262.

## Problem

`wily rank` (without `--revision`) ranks against the most recent revision. But wily v2 stores metrics as **deltas** — a full "seed" revision plus only the files that changed in each subsequent revision. The previous implementation built its lookup from rows whose `revision` exactly matched the target revision:

```python
for row in index:
    if row["revision"] == target_revision_key:
        revision_data[row["path"]] = row.get(resolved_metric.name)
```

So on any real repository, the latest revision contains only the file(s) changed in the last commit, and `wily rank` listed ~1 file by default. The no-path variant also surfaced directory/root aggregate rows that all shared an identical value.

### Before (microsoft/graphrag, default latest revision)

```
$ wily rank packages/graphrag/graphrag raw.loc
┌────────────────────────────────────────────────────────────┬───────────────┐
│ File                                                       │ Lines of Code │
│ packages/graphrag/graphrag/index/utils/derive_from_rows.py │ 182           │
└────────────────────────────────────────────────────────────┴───────────────┘
```

### After

```
$ wily rank packages/graphrag/graphrag raw.loc -l 10
┌─────────────────────────────────────────────────────────────┬───────────────┐
│ File                                                        │ Lines of Code │
│ packages/graphrag/graphrag/cache/__init__.py                │ 5             │
│ packages/graphrag/graphrag/callbacks/__init__.py            │ 5             │
│ ... (all files in the project)                              │ ...           │
└─────────────────────────────────────────────────────────────┴───────────────┘
```

## Fix

In `src/wily/commands/rank.py`, reconstruct the project state at the target revision by taking, for each file path, the most recent row at or before the target revision's date — instead of exact-matching `revision`. Ranking is also restricted to `path_type == "file"` rows, so directory/root aggregates and function/class detail rows no longer pollute the table with duplicate values.

## Tests

Added `test_rank_latest_includes_unchanged_files`, which builds a repo where `src/stable.py` exists only in the seed commit and `src/churn.py` is modified in a later commit, then asserts both appear when ranking the latest revision. (The existing `gitdir` fixture has a single file that changes in every commit, so it never exercised this bug.)

All `test/integration/test_rank.py` tests pass (16 passed); `ruff check` is clean.
